### PR TITLE
faust: Remove Android native libraries

### DIFF
--- a/faust/faust.spec
+++ b/faust/faust.spec
@@ -219,6 +219,8 @@ rm %{buildroot}%{_datadir}/faust/webaudio/osc.wasm
 
 rm %{buildroot}/%{_libdir}/ios-libsndfile.a
 
+rm %{buildroot}%{_datadir}/faust/android/app/lib/libsndfile/lib/*/libsndfile.so
+
 mv %{buildroot}/%{_bindir}/usage.sh %{buildroot}/%{_datadir}/faust/
 
 %ldconfig_scriptlets osclib


### PR DESCRIPTION
Fixes #9
The faust package contains .so libraries prebuilt for Android.
These libraries confuse the ELF dependency finder of RPM, which
adds unsatisfiable .so dependencies.