### PR TITLE
Fix surge-xt 1.1.1

### DIFF
--- a/surge/surge-pr6608.patch
+++ b/surge/surge-pr6608.patch
@@ -1,0 +1,24 @@
+diff --git a/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp b/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
+index ea3b546b544..c4b6e31d55c 100644
+--- a/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
++++ b/src/surge-xt/gui/widgets/XMLConfiguredMenus.cpp
+@@ -697,11 +697,14 @@ void FxMenu::populateForContext(bool isCalledInEffectChooser)
+     if (sge)
+     {
+         cfxid = sge->effectChooser->currentClicked;
+-        auto deactbm = sge->effectChooser->getDeactivatedBitmask();
+-        addDeact = true;
+-        isDeact = deactbm & (1 << cfxid);
+-        cfxtype = sge->effectChooser->fxTypes[cfxid];
+-        enableClear = cfxtype != fxt_off;
++        if (cfxid >= 0)
++        {
++            auto deactbm = sge->effectChooser->getDeactivatedBitmask();
++            addDeact = true;
++            isDeact = deactbm & (1 << cfxid);
++            cfxtype = sge->effectChooser->fxTypes[cfxid];
++            enableClear = cfxtype != fxt_off;
++        }
+     }
+ 
+     auto cfx = std::string{"Current FX Slot"};

--- a/surge/surge-xt.spec
+++ b/surge/surge-xt.spec
@@ -6,7 +6,7 @@
 
 Name:    surge-xt
 Version: 1.1.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: A VST3 Synthesizer and Effects, including Airwindows
 License: GPLv2+
 URL:     https://github.com/surge-synthesizer/surge
@@ -19,6 +19,8 @@ Distribution: Audinux
 
 Source0: surge.tar.gz
 Source1: source-surge.sh
+
+Patch0: surge-pr6608.patch
 
 BuildRequires: gcc gcc-c++
 BuildRequires: cmake
@@ -93,6 +95,9 @@ sed -i -e "s/Surge_XT Effects/Surge_XT_Effects/g" src/surge-fx/CMakeLists.txt
 %{_libdir}/clap/*
 
 %changelog
+* Fri Sep 23 2022 Jean Pierre Cimalando <jp-dev@gmx.com> - 1.1.1-2
+- add patch to fix an out-of-bounds array access
+
 * Fri Aug 26 2022 Yann Collette <ycollette.nospam@free.fr> - 1.1.1-1
 - update to 1.1.1-1
 


### PR DESCRIPTION
This adds the patch from upstream which fixes #21.

The particularity is that fedora has the optflag `-D_GLIBCXX_ASSERTIONS`. (cf. [HardeningFlags])
This introduces mandatory bounds-checking on c++ containers.

[HardeningFlags]: https://fedoraproject.org/wiki/Changes/HardeningFlags28

---
On another note: this reveals bugs but otoh it could give degraded performance for DSP code,
since it branches in the sample loop and is a blocker of simd optimizations.
That's if one wants to use c++ containers. (note to self: avoid doing it)
I found that there exists a workaround to turn this off.
`%global optflags %{optflags} -Wp,-U_GLIBCXX_ASSERTIONS`