### PR TITLE
Fix unowned dirs

### DIFF
--- a/adlplug/opl3bankeditor.spec
+++ b/adlplug/opl3bankeditor.spec
@@ -72,7 +72,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/opl3_bank_editor.desk
 %{_datadir}/mime/*
 %{_datadir}/applications/*
 %{_datadir}/icons/*
-%{_datadir}/opl3_bank_editor/*
+%{_datadir}/opl3_bank_editor/
 
 %changelog
 * Thu Oct 1 2020 Yann Collette <ycollette.nospam@free.fr> - 1.5.1-2

--- a/adlplug/opn2bankeditor.spec
+++ b/adlplug/opn2bankeditor.spec
@@ -71,7 +71,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/opn2_bank_editor.desk
 %{_bindir}/opn2_bank_editor
 %{_datadir}/applications/*
 %{_datadir}/icons/*
-%{_datadir}/opn2_bank_editor/*
+%{_datadir}/opn2_bank_editor/
 
 %changelog
 * Thu Oct 1 2020 Yann Collette <ycollette.nospam@free.fr> - 1.3.0-2

--- a/aeolus_plugin/aeolus_plugin.spec
+++ b/aeolus_plugin/aeolus_plugin.spec
@@ -118,7 +118,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/Aeolus.desktop
 %doc README.md
 %license LICENSE.txt
 %{_bindir}/*
-%{_datadir}/Aeolus/*
+%{_datadir}/Aeolus/
 %{_datadir}/icons/hicolor/256x256/*
 %{_datadir}/icons/hicolor/64x64/*
 %{_datadir}/applications/*

--- a/amsynth/amsynth.spec
+++ b/amsynth/amsynth.spec
@@ -84,7 +84,7 @@ appstream-util validate-relax --nonet %{buildroot}%{_datadir}/appdata/%{name}.ap
 %doc AUTHORS ChangeLog NEWS README
 %license COPYING
 %{_bindir}/amsynth
-%{_datadir}/amsynth/*
+%{_datadir}/amsynth/
 %{_datadir}/appdata/%{name}.appdata.xml
 %{_datadir}/applications/*%{name}.desktop
 %{_datadir}/icons/hicolor/48x48/apps/amsynth.png

--- a/amuc/amuc.spec
+++ b/amuc/amuc.spec
@@ -67,8 +67,8 @@ rm %{buildroot}/%{_docdir}/amuc/amuc.1
 %doc README
 %license LICENSE
 %{_bindir}/*
-%{_datadir}/amuc/*
-%{_docdir}/amuc/*
+%{_datadir}/amuc/
+%{_docdir}/amuc/
 %{_mandir}/man1/*
 
 %changelog

--- a/bipscript/bipscript.spec
+++ b/bipscript/bipscript.spec
@@ -78,12 +78,13 @@ cp -ra apidocs/en %{buildroot}/%{_datadir}/bipscript/apidocs/
 %doc README.md
 %license LICENSE
 %{_bindir}/*
+%dir %{_datadir}/bipscript/
 
 %files doc
-%{_datadir}/bipscript/apidocs/*
+%{_datadir}/bipscript/apidocs/
 
 %files examples
-%{_datadir}/bipscript/examples/*
+%{_datadir}/bipscript/examples/
 
 %changelog
 * Fri Mar 31 2023 Yann Collette <ycollette.nospam@free.fr> - 0.18-1

--- a/buzztracx/buzztrax.spec
+++ b/buzztracx/buzztrax.spec
@@ -97,7 +97,7 @@ desktop-file-validate %{buildroot}/%{_datadir}/applications/%{name}-songio-buzz.
 %{_datadir}/gtk-doc/html/buzztrax-*
 %{_bindir}/buzztrax-cmd
 %{_bindir}/buzztrax-edit
-%{_libdir}/buzztrax-songio/*
+%{_libdir}/buzztrax-songio/
 %{_libdir}/buzztrax
 %{_libdir}/gstreamer-1.0/libbuzztrax*
 %{_libdir}/gstreamer-1.0/libgstbml.*

--- a/cabbage/cabbage.spec
+++ b/cabbage/cabbage.spec
@@ -149,6 +149,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/Cabbage.desktop
 %{_datadir}/applications/*
 %{_datadir}/icons/hicolor/scalable/apps/*
 %{_datadir}/icons/hicolor/apps/512x512/*
+%{_datadir}/cabbage/
 %{_datadir}/cabbage/docs/*
 %{_datadir}/cabbage/examples/*
 %{_datadir}/cabbage/themes/*

--- a/camomile/camomile.spec
+++ b/camomile/camomile.spec
@@ -75,7 +75,7 @@ cp Camomile_LV2.so lv2_file_generator %{buildroot}/%{_datadir}/%{name}/lv2/
 %doc README.md
 %license LICENSE
 %{_bindir}/*
-%{_datadir}/%{name}/*
+%{_datadir}/%{name}/
 
 %files -n vst3-%{name}
 %{_libdir}/vst3/*

--- a/cm/cm.spec
+++ b/cm/cm.spec
@@ -62,6 +62,7 @@ cp -ra res/* %{buildroot}/%{_datadir}/cm/res/
 %files
 %doc readme.text
 %{_bindir}/*
+%{_datadir}/cm/
 %{_datadir}/cm/res/*
 
 %changelog

--- a/ddsp/ddsp.spec
+++ b/ddsp/ddsp.spec
@@ -136,6 +136,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/DDSP_Synth.desktop
 %doc README.md
 %license LICENSE
 %{_bindir}/*
+%{_datadir}/%{name}/
 %{_datadir}/%{name}/models/*
 %{_datadir}/applications/*
 %{_datadir}/icons/hicolor/scalable/apps/*

--- a/din/din.spec
+++ b/din/din.spec
@@ -110,7 +110,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/din-jack.desktop
 %doc AUTHORS CHANGELOG BUGS INSTALL NEWS README TODO
 %license COPYING
 %{_bindir}/*
-%{_datadir}/%{name}/*
+%{_datadir}/%{name}/
 %{_datadir}/applications/din.desktop
 %{_datadir}/icons/hicolor/scalable/apps/din.svg
 %{_datadir}/pixmaps/din.png

--- a/elektroid/elektroid.spec
+++ b/elektroid/elektroid.spec
@@ -57,7 +57,7 @@ appstream-util validate-relax --nonet %{buildroot}%{_metainfodir}/%{name}.appdat
 %license COPYING
 %{_bindir}/*
 %{_datadir}/applications/*
-%{_datadir}/elektroid/*
+%{_datadir}/elektroid/
 %{_datadir}/icons/hicolor/*
 %{_datadir}/locale/*
 %{_datadir}/metainfo/elektroid.appdata.xml

--- a/element/element.spec
+++ b/element/element.spec
@@ -85,7 +85,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/net.kushview.element.
 %license LICENSE
 %{_bindir}/*
 %{_datadir}/applications/*
-%{_datadir}/element/*
+%{_datadir}/element/
 %{_datadir}/icons/hicolor/*
 
 %changelog

--- a/emissioncontrol2/emissioncontrol2.spec
+++ b/emissioncontrol2/emissioncontrol2.spec
@@ -105,6 +105,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 %{_bindir}/*
 %{_datadir}/pixmaps/*
 %{_datadir}/applications/*
+%{_datadir}/emissioncontrol2/
 %{_datadir}/emissioncontrol2/samples/*
 
 %changelog

--- a/fluxus/fluxus.spec
+++ b/fluxus/fluxus.spec
@@ -130,9 +130,9 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/fluxus.desktop
 %files
 %{_bindir}/fluxus
 %{_bindir}/fluxa
-%{_libdir}/fluxus-019/*
-%{_datadir}/fluxus-019/*
-%{_docdir}/fluxus-019/*
+%{_libdir}/fluxus-019/
+%{_datadir}/fluxus-019/
+%{_docdir}/fluxus-019/
 %{_datadir}/pixmaps/fluxus-icon.png
 %{_datadir}/applications/fluxus.desktop
 

--- a/fmit/fmit.spec
+++ b/fmit/fmit.spec
@@ -82,6 +82,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/*.desktop
 %{_metainfodir}/*
 %{_datadir}/applications/*
 %{_datadir}/icons/hicolor/scalable/apps/*
+%{_datadir}/fmit/
 %{_datadir}/fmit/scales/*
 
 %changelog

--- a/focusrite/focusrite.spec
+++ b/focusrite/focusrite.spec
@@ -74,6 +74,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/*.desktop
 %files
 %doc README.md USAGE.md INTERFACES.md
 %{_bindir}/*
+%{_datadir}/%{name}/
 %{_datadir}/%{name}/doc/*
 %{_datadir}/applications/alsa-scarlett-gui.desktop
 %{_datadir}/icons/hicolor/256x256/apps/alsa-scarlett-gui.png

--- a/furnace/furnace.spec
+++ b/furnace/furnace.spec
@@ -78,7 +78,9 @@ appstream-util validate-relax --nonet %{buildroot}%{_datadir}/metainfo/%{name}.a
 %doc README.md
 %{_bindir}/*
 %{_datadir}/applications/%{name}.desktop
+%{_datadir}/doc/furnace/
 %{_datadir}/doc/furnace/papers/*
+%{_datadir}/furnace/
 %{_datadir}/furnace/demos/*
 %{_datadir}/icons/hicolor/1024x1024/apps/%{name}.png
 %{_datadir}/metainfo/%{name}.appdata.xml

--- a/gammou/gammou.spec
+++ b/gammou/gammou.spec
@@ -125,6 +125,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 %{_libdir}/*
 %{_datadir}/icons/hicolor/256x256/apps/*
 %{_datadir}/applications/*
+%{_datadir}/%{name}/
 %{_datadir}/%{name}/packages/*
 %{_datadir}/%{name}/waves/.empty
 

--- a/goatracker/goatracker.spec
+++ b/goatracker/goatracker.spec
@@ -81,7 +81,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/goatracker.desktop
 %doc authors readme_resid.txt readme_sdl.txt readme.txt
 %license copying
 %{_bindir}/*
-%{_datadir}/%{name}/*
+%{_datadir}/%{name}/
 %{_datadir}/pixmaps/*
 %{_datadir}/applications/*
 

--- a/helioworkstation/helioworkstation.spec
+++ b/helioworkstation/helioworkstation.spec
@@ -77,7 +77,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 %{_bindir}/*
 %{_datadir}/applications/*
 %{_datadir}/icons/hicolor/*
-%{_datadir}/doc/%{name}/*
+%{_datadir}/doc/%{name}/
 
 %changelog
 * Sun Apr 23 2023 Yann Collette <ycollette.nospam@free.fr> - 3.11.0-2

--- a/helm/helm.spec
+++ b/helm/helm.spec
@@ -79,8 +79,8 @@ appstream-util validate-relax --nonet %{buildroot}%{_metainfodir}/*.appdata.xml
 %{_bindir}/*
 %{_libdir}/lv2/*
 %{_libdir}/lxvst/*
-%{_datadir}/helm/*
-%{_datadir}/doc/helm/*
+%{_datadir}/helm/
+%{_datadir}/doc/helm/
 %{_mandir}/man1/helm.1.gz
 %{_datadir}/applications/helm.desktop
 %{_datadir}/icons/hicolor/*

--- a/hexosynth/hexosynth.spec
+++ b/hexosynth/hexosynth.spec
@@ -80,6 +80,7 @@ cp -vfr build/clap/hexosynth_plug.clap %{buildroot}/%{_libdir}/clap/
 %license COPYING
 %{_bindir}/hexosynth_jack
 %{_bindir}/hexosynth
+%{_datadir}/hexosynth/
 %{_datadir}/hexosynth/examples/*
 %{_libdir}/vst/*
 %{_libdir}/vst3/*

--- a/hise/hise.spec
+++ b/hise/hise.spec
@@ -115,6 +115,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 %{_bindir}/*
 %{_datadir}/applications/*
 %{_datadir}/icons/*
+%{_datadir}/%{name}/
 %{_datadir}/%{name}/demos/*
 
 %files -n vst-%{name}

--- a/hivelytracker/hivelytracker.spec
+++ b/hivelytracker/hivelytracker.spec
@@ -79,7 +79,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 %license LICENSE
 %doc ChangeLog.txt
 %{_bindir}/*
-%{_datadir}/%{name}/*
+%{_datadir}/%{name}/
 %{_datadir}/applications/*
 %{_datadir}/icons/*
 %{_mandir}/man1/*

--- a/horgand/horgand.spec
+++ b/horgand/horgand.spec
@@ -84,7 +84,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 %license COPYING
 %{_bindir}/%{name}
 %{_datadir}/man/*
-%{_datadir}/horgand/*
+%{_datadir}/horgand/
 %{_datadir}/applications/*
 %{_datadir}/icons/*
 

--- a/hybridreverb2/hybridreverb.spec
+++ b/hybridreverb2/hybridreverb.spec
@@ -111,7 +111,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/hybridreverb2.desktop
 %{_libdir}/lv2/*
 
 %files -n %{name}-common
-%{_datadir}/HybridReverb2/*
+%{_datadir}/HybridReverb2/
 
 %changelog
 * Thu Nov 26 2020 Yann Collette <ycollette.nospam@free.fr> - 2.1.2-1

--- a/hydrogen/hydrogen.spec
+++ b/hydrogen/hydrogen.spec
@@ -98,7 +98,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/org.hydrogenmusic.Hyd
 %{_bindir}/hydrogen
 %{_bindir}/h2cli
 %{_bindir}/h2player
-%{_datadir}/hydrogen/*
+%{_datadir}/hydrogen/
 %{_datadir}/icons/*
 %{_datadir}/applications/*.desktop
 %{_datadir}/appdata/*.appdata.xml

--- a/impro-visor/improvisor.spec
+++ b/impro-visor/improvisor.spec
@@ -179,6 +179,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 %license LICENSE.txt
 %{_bindir}/*
 %{_javadir}/*.jar
+%{_datadir}/%{name}/
 %{_datadir}/%{name}/.install4j/*
 %{_datadir}/%{name}/grammars/*
 %{_datadir}/%{name}/leadsheets/*

--- a/improviz/improviz.spec
+++ b/improviz/improviz.spec
@@ -82,7 +82,7 @@ cp -ra improviz-performance-main/* %{buildroot}/%{_datadir}/%{name}/examples/
 %doc README.md
 %license LICENSE
 %{_bindir}/*
-%{_datadir}/%{name}/*
+%{_datadir}/%{name}/
 
 %changelog
 * Mon Jan 30 2023 Yann Collette <ycollette dot nospam at free.fr> 1.1-3

--- a/jack-director/cyclone.spec
+++ b/jack-director/cyclone.spec
@@ -78,6 +78,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 %{_bindir}/*
 %{_datadir}/applications/*
 %{_datadir}/pixmaps/*
+%{_datadir}/%{name}/
 %{_datadir}/%{name}/help/*
 %{_datadir}/mime/packages/*
 

--- a/jack-director/jack-director.spec
+++ b/jack-director/jack-director.spec
@@ -52,7 +52,7 @@ install -m 755 jack-directorrc %{buildroot}/%{_datadir}/jack-director/
 %doc README
 %license gpl-3.0.txt gpl-2.0.txt
 %{_bindir}/*
-%{_datadir}/jack-director/*
+%{_datadir}/jack-director/
 
 %changelog
 * Fri Dec 02 2022 Yann Collette <ycollette.nospam@free.fr> - 0.1.1-1

--- a/jjazzlab/jjazzlab.spec
+++ b/jjazzlab/jjazzlab.spec
@@ -85,7 +85,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 %doc README.md
 %license LICENSE
 %{_bindir}/*
-%{_datadir}/jjazzlab/*
+%{_datadir}/jjazzlab/
 %{_datadir}/icons/hicolor/scalable/apps/*
 %{_datadir}/applications/*
 

--- a/klystrack/klystrack.spec
+++ b/klystrack/klystrack.spec
@@ -135,7 +135,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/*.desktop
 %doc README.md
 %license LICENSE
 %{_bindir}/*
-%{_datadir}/%{name}/*
+%{_datadir}/%{name}/
 %{_datadir}/applications/*
 %{_datadir}/icons/*
 

--- a/komposter/komposter.spec
+++ b/komposter/komposter.spec
@@ -49,6 +49,7 @@ cp -r resources/komposter_icon.png %{buildroot}%{_datadir}/icons/hicolor/256x256
 %license LICENSE
 %doc README.md
 %{_bindir}/*
+%{_datadir}/%{name}/
 %{_datadir}/%{name}/doc/*
 %{_datadir}/%{name}/resources/*
 %{_datadir}/%{name}/examples/*

--- a/kxstudio/cadence.spec
+++ b/kxstudio/cadence.spec
@@ -59,7 +59,7 @@ Set of tools useful for audio production.
 %license COPYING
 %{_bindir}/*
 %{_datadir}/applications/*
-%{_datadir}/cadence/*
+%{_datadir}/cadence/
 %{_datadir}/icons/*
 %{_sysconfdir}/*
 

--- a/kxstudio/cardinal.spec
+++ b/kxstudio/cardinal.spec
@@ -122,8 +122,8 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 %files
 %license LICENSE
 %{_bindir}/*
-%{_datadir}/%{name}/*
-%{_datadir}/doc/%{name}/*
+%{_datadir}/%{name}/
+%{_datadir}/doc/%{name}/
 %{_datadir}/applications/*
 %{_datadir}/icons/hicolor/scalable/apps/*
 

--- a/lebiniou/ulfius.spec
+++ b/lebiniou/ulfius.spec
@@ -63,7 +63,7 @@ The %{name}-doc package contains documentation for %{name}.
 %{_libdir}/pkgconfig/*.pc
 
 %files doc
-%{_datadir}/doc/ulfius/*
+%{_datadir}/doc/ulfius/
 
 %changelog
 * Sun Dec 13 2020 Yann Collette <ycollette dot nospam at free.fr> 2.7.0-1

--- a/lenmus/lenmus.spec
+++ b/lenmus/lenmus.spec
@@ -78,7 +78,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 %doc AUTHORS CHANGELOG.md INSTALL README.md NEWS THANKS
 %license LICENSE
 %{_bindir}/%{name}
-%{_datadir}/%{name}/*
+%{_datadir}/%{name}/
 %{_datadir}/applications/%{name}.desktop
 %{_datadir}/pixmaps/%{name}.png
 %{_datadir}/man/*

--- a/lenmus/lomse.spec
+++ b/lenmus/lomse.spec
@@ -55,6 +55,7 @@ The %{name}-devel package contains header files for %{name}.
 %doc AUTHORS.md CHANGELOG.md README.md NEWS THANKS CONTRIBUTING.md
 %license LICENSE
 %{_libdir}/*
+%{_datadir}/%{name}/
 %{_datadir}/%{name}/fonts/*
 
 %files devel

--- a/linuxsampler/qsampler.spec
+++ b/linuxsampler/qsampler.spec
@@ -66,6 +66,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/*.desktop
 %{_datadir}/mime/packages/*
 %{_datadir}/applications/*
 %{_datadir}/metainfo/*
+%{_datadir}/qsampler/
 %{_datadir}/qsampler/translations/*
 %{_mandir}/*
 

--- a/linvst/linvst.spec
+++ b/linvst/linvst.spec
@@ -64,6 +64,7 @@ cp manage/README.md %{buildroot}/%{_datadir}/%{name}/manage/
 %{_bindir}/lin-vst-servertrack32.exe
 %{_bindir}/lin-vst-servertrack32.exe.so
 %{_bindir}/linvstconvert
+%{_datadir}/%{name}/
 %{_datadir}/%{name}/64bit-32bit/linvst.so
 %{_datadir}/%{name}/doc/*
 %{_datadir}/%{name}/manage/*

--- a/lmms/lmms.spec
+++ b/lmms/lmms.spec
@@ -158,7 +158,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/lmms.desktop
 %license LICENSE.txt
 %{_bindir}/lmms
 %{_mandir}/man1/*
-%{_libdir}/lmms/*
+%{_libdir}/lmms/
 %{_datadir}/lmms/
 %{_datadir}/applications/lmms.desktop
 %{_datadir}/icons/hicolor/*

--- a/loopidity/loopidity.spec
+++ b/loopidity/loopidity.spec
@@ -67,7 +67,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 %license COPYING
 %{_bindir}/*
 %{_datadir}/applications/*.desktop
-%{_datadir}/doc/%{name}/*
+%{_datadir}/doc/%{name}/
 %{_datadir}/pixmaps/*
 %{_mandir}/man1/*
 

--- a/lpd8editor/lpd8editor.spec
+++ b/lpd8editor/lpd8editor.spec
@@ -73,7 +73,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 %{_bindir}/%{name}
 %{_datadir}/applications/*
 %{_datadir}/icons/hicolor/scalable/apps
-%{_datadir}/%{name}/*
+%{_datadir}/%{name}/
 
 %changelog
 * Sun Apr 17 2022 Yann Collette <ycollette.nospam@free.fr> - 0.0.16-1

--- a/lv2/lv2-foo-yc20.spec
+++ b/lv2/lv2-foo-yc20.spec
@@ -51,6 +51,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/foo-yc20.desktop
 %{_bindir}/*
 %{_libdir}/lv2/*
 %{_datadir}/applications/*
+%{_datadir}/foo-yc20/
 %{_datadir}/foo-yc20/graphics/*
 
 %changelog

--- a/mandelbulber2/mandelbulber2.spec
+++ b/mandelbulber2/mandelbulber2.spec
@@ -69,7 +69,8 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 %license COPYING
 %{_bindir}/%{name}
 %{_datadir}/applications/%{name}.desktop
-%{_datadir}/%{name}/*
+%{_datadir}/%{name}/
+%{_datadir}/doc/%{name}/
 %{_datadir}/doc/%{name}/Mandelbulber_Manual.pdf
 %{_datadir}/pixmaps/mandelbulber.png
 

--- a/midieditor/midieditor.spec
+++ b/midieditor/midieditor.spec
@@ -83,6 +83,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 %{_datadir}/applications/%{name}.desktop
 %{_datadir}/icons/hicolor/16x16/apps/%{name}.ico
 %{_datadir}/icons/hicolor/48x48/apps/%{name}.png
+%{_datadir}/midieditor/
 %{_datadir}/midieditor/manual/*
 %{_datadir}/midieditor/examples/*
 %{_datadir}/midieditor/metronome/*

--- a/midimonster/midimonster.spec
+++ b/midimonster/midimonster.spec
@@ -39,8 +39,8 @@ sed -i -e "s/lua53/lua/g" backends/Makefile
 %doc README.md
 %license LICENSE.txt
 %{_bindir}/*
-%{_libdir}/%{name}/*
-%{_datadir}/%{name}/*
+%{_libdir}/%{name}/
+%{_datadir}/%{name}/
 
 %changelog
 * Wed Jun 30 2021 Yann Collette <ycollette.nospam@free.fr> - 0.6.0-1

--- a/midivisualizer/midivisualizer.spec
+++ b/midivisualizer/midivisualizer.spec
@@ -77,6 +77,7 @@ desktop-file-install                         \
 %doc README.md
 %license LICENSE
 %{_bindir}/*
+%{_libdir}/midivisualizer/
 %{_libdir}/midivisualizer/liblibremidi.so
 %{_datadir}/icons/hicolor/256x256/apps/*
 %{_datadir}/applications/*

--- a/milkytracker/milkytracker.spec
+++ b/milkytracker/milkytracker.spec
@@ -59,8 +59,9 @@ desktop-file-install \
 %{_bindir}/milkytracker
 %{_datadir}/applications/*
 %{_datadir}/pixmaps/milkytracker.png
+%{_datadir}/milkytracker/
 %{_datadir}/milkytracker/songs/*
-%{_datadir}/doc/MilkyTracker/*
+%{_datadir}/doc/MilkyTracker/
 
 %changelog
 * Thu Dec 10 2020 Yann Collette <ycollette dot nospam at free dot fr> 1.03.00-2

--- a/minicomputer/minicomputer.spec
+++ b/minicomputer/minicomputer.spec
@@ -79,7 +79,7 @@ cp -r factoryPresets/*    %{buildroot}/%{_datadir}/%{name}/presets/
 %doc README
 %license COPYING
 %{_bindir}/*
-%{_datadir}/%{name}/*
+%{_datadir}/%{name}/
 %{_datadir}/pixmaps/*
 
 %files -n lv2-%{name}

--- a/mpk-m2-editor/mpk-m2-editor.spec
+++ b/mpk-m2-editor/mpk-m2-editor.spec
@@ -71,7 +71,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 %{_bindir}/%{name}
 %{_datadir}/applications/*
 %{_datadir}/icons/hicolor/*
-%{_datadir}/%{name}/*
+%{_datadir}/%{name}/
 %{python3_sitelib}/mpk_m2_editor_ui/*
 %{python3_sitelib}/%{libname}-*.egg-info/
 

--- a/mv-6pm/mv-6pm.spec
+++ b/mv-6pm/mv-6pm.spec
@@ -72,7 +72,7 @@ desktop-file-install --vendor '' \
 %license LICENSE
 %{_bindir}/%{name}
 %{_datadir}/applications/%{name}.desktop
-%{_datadir}/mv-6pm/*
+%{_datadir}/mv-6pm/
 %{_datadir}/icons/hicolor/*
 
 %changelog

--- a/neothesia/neothesia.spec
+++ b/neothesia/neothesia.spec
@@ -74,6 +74,7 @@ appstream-util validate-relax --nonet %{buildroot}%{_datadir}/metainfo/com.githu
 %doc README.md
 %license LICENSE
 %{_bindir}/*
+%{_datadir}/neothesia/
 %{_datadir}/neothesia/sf2/*
 %{_datadir}/neothesia/midi/*
 %{_datadir}/applications/com.github.polymeilex.neothesia.desktop

--- a/ninjam/ninjam-server.spec
+++ b/ninjam/ninjam-server.spec
@@ -38,7 +38,7 @@ install -m 644 ninjam/server/example.cfg %{buildroot}%{_datadir}/ninjam/
 %files
 %doc ninjam/server/license.txt ninjam/server/cclicense.txt
 %{_bindir}/*
-%{_datadir}/ninjam/*
+%{_datadir}/ninjam/
 
 %changelog
 * Mon Oct 19 2020 Yann Collette <ycollette.nospam@free.fr> - 0.0.1-2

--- a/orca/orca.spec
+++ b/orca/orca.spec
@@ -64,7 +64,7 @@ cp -r Orca-main/resources %{buildroot}/%{_datadir}/%{name}/documentation
 %doc README.md
 %license LICENSE.md
 %{_bindir}/*
-%{_datadir}/%{name}/*
+%{_datadir}/%{name}/
 
 %changelog
 * Sun Oct 09 2022 Yann Collette <ycollette.nospam@free.fr> - 0.1.0.d027a414-3

--- a/padthv1/padthv1.spec
+++ b/padthv1/padthv1.spec
@@ -87,6 +87,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/org.rncbc.padthv1.des
 %{_datadir}/man/*/man1/%{name}*
 %{_datadir}/mime/packages/*.xml
 %{_datadir}/metainfo/*.xml
+%{_datadir}/%{name}/
 %{_datadir}/%{name}/presets/*
 
 %files -n lv2-%{name}

--- a/paulstretch/paulstretch_cpp.spec
+++ b/paulstretch/paulstretch_cpp.spec
@@ -94,7 +94,7 @@ desktop-file-validate %{buildroot}/%{_datadir}/applications/%{name}-jack.desktop
 %doc readme.txt
 %{_bindir}/*
 %{_datadir}/applications/*
-%{_datadir}/icons/%{name}/*
+%{_datadir}/icons/%{name}/
 
 %changelog
 * Tue Jan 17 2023 Yann Collette <ycollette.nospam@free.fr> - 2.1.0-1

--- a/playitslowly/playitslowly.spec
+++ b/playitslowly/playitslowly.spec
@@ -52,7 +52,7 @@ appstream-util validate-relax --nonet %{buildroot}/%{_datadir}/appdata/*.appdata
 %doc README.rst
 %license COPYING
 %{_bindir}/%{name}
-%{python3_sitelib}/%{name}/*
+%{python3_sitelib}/%{name}/
 %{python3_sitelib}/%{name}-*.egg-info
 %{_datadir}/applications/*
 %{_datadir}/appdata/*

--- a/powertab/powertab.spec
+++ b/powertab/powertab.spec
@@ -66,7 +66,7 @@ appstream-util validate-relax --nonet %{buildroot}%{_datadir}/metainfo/powertabe
 %{_datadir}/icons/*
 %{_datadir}/metainfo/*
 %{_datadir}/mime/*
-%{_datadir}/powertab/*     
+%{_datadir}/powertab/
 
 %changelog
 * Fri Jul 08 2022 Yann Collette <ycollette.nospam@free.fr> - 0.0.1-1

--- a/prom/prom.spec
+++ b/prom/prom.spec
@@ -111,6 +111,7 @@ ln -s %{_datadir}/ProM/data/fonts %{buildroot}/%{_libdir}/vst3/ProM.vst3/Content
 %files
 %doc README.md
 %license LICENSE
+%{_datadir}/ProM/
 %{_datadir}/ProM/data/*
 
 %files -n vst-%{name}

--- a/protracker/protracker.spec
+++ b/protracker/protracker.spec
@@ -137,7 +137,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}-alsa.desktop
 %{_bindir}/protracker2-jack
 %{_bindir}/protracker2-pulse
 %{_bindir}/protracker2-alsa
-%{_datadir}/%{name}/*
+%{_datadir}/%{name}/
 %{_datadir}/icons/*
 %{_datadir}/applications/*
 

--- a/psindustrializer/psindustrializer.spec
+++ b/psindustrializer/psindustrializer.spec
@@ -71,7 +71,7 @@ appstream-util validate-relax --nonet %{buildroot}%{_datadir}/appdata/%{name}.ap
 %{_datadir}/applications/*
 %{_datadir}/locale/*
 %{_datadir}/pixmaps/*
-%{_datadir}/psindustrializer/*
+%{_datadir}/psindustrializer/
 
 %changelog
 * Mon Dec 13 2021 Yann Collette <ycollette.nospam@free.fr> - 0.2.7-1

--- a/pure-data/hvcc.spec
+++ b/pure-data/hvcc.spec
@@ -51,8 +51,9 @@ rm -rf %{buildroot}/%{python3_sitelib}/tests
 %doc README.md
 %license LICENSE
 %{_bindir}/*
-%{python3_sitelib}/%{name}/*
+%{python3_sitelib}/%{name}/
 %{python3_sitelib}/%{name}-*.egg-info
+%{_datadir}/%{name}/
 %{_datadir}/%{name}/docs/*
 %{_datadir}/%{name}/examples/*
 

--- a/qutecsound/qutecsound.spec
+++ b/qutecsound/qutecsound.spec
@@ -99,7 +99,7 @@ desktop-file-install --vendor '' \
 %{_datadir}/applications/qutecsound.desktop
 %{_datadir}/mime/packages/qutecsound.xml
 %{_datadir}/icons/hicolor/*
-%{_datadir}/%{name}/*
+%{_datadir}/%{name}/
 
 %changelog
 * Mon Oct 26 2020 Yann Collette <ycollette.nospam@free.fr> - 0.9.8.1-3

--- a/rakarrack-plus/rakarrack-plus.spec
+++ b/rakarrack-plus/rakarrack-plus.spec
@@ -93,8 +93,8 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/rakarrack-plus.deskto
 %{_datadir}/applications/*
 %{_datadir}/man/*
 %{_datadir}/pixmaps/*
-%{_datadir}/rakarrack-plus/*
-%{_datadir}/RakarrackPlus.lv2/*
+%{_datadir}/rakarrack-plus/
+%{_datadir}/RakarrackPlus.lv2/
 %{_datadir}/doc/rakarrack-plus/html/*
 
 %files -n lv2-%{name}

--- a/rakarrack/rakarrack.spec
+++ b/rakarrack/rakarrack.spec
@@ -84,7 +84,7 @@ desktop-file-install --vendor '' \
 %{_datadir}/doc/*
 %{_datadir}/man/*
 %{_datadir}/pixmaps/*
-%{_datadir}/rakarrack/*
+%{_datadir}/rakarrack/
 
 %changelog
 * Wed Nov 4 2020 Yann Collette <ycollette dot nospam at free.fr> 0.6.3-2

--- a/raysession/patchance.spec
+++ b/raysession/patchance.spec
@@ -72,6 +72,7 @@ desktop-file-validate  %{buildroot}/%{_datadir}/applications/%{name}.desktop
 %{_bindir}/*
 %{_datadir}/applications/*
 %{_datadir}/icons/*
+%{_datadir}/patchance/
 %{_datadir}/patchance/HoustonPatchbay/*
 %{_datadir}/patchance/locale/*
 %{_datadir}/patchance/src/*

--- a/raysession/patchichi.spec
+++ b/raysession/patchichi.spec
@@ -69,6 +69,7 @@ desktop-file-validate  %{buildroot}/%{_datadir}/applications/%{name}.desktop
 %{_bindir}/*
 %{_datadir}/applications/*
 %{_datadir}/icons/*
+%{_datadir}/patchichi/
 %{_datadir}/patchichi/HoustonPatchbay/*
 %{_datadir}/patchichi/locale/*
 %{_datadir}/patchichi/src/*

--- a/raysession/raysession.spec
+++ b/raysession/raysession.spec
@@ -108,7 +108,8 @@ desktop-file-validate  %{buildroot}/%{_datadir}/applications/ray-network.desktop
 %{_bindir}/*
 %{_datadir}/applications/*
 %{_datadir}/icons/*
-%{_datadir}/raysession/*
+%{_datadir}/raysession/
+%{_sysconfdir}/xdg/raysession/
 %{_sysconfdir}/xdg/raysession/client_templates/*
 
 %changelog

--- a/resources/impulse_response.spec
+++ b/resources/impulse_response.spec
@@ -41,7 +41,7 @@ mkdir -p %{buildroot}/%{_datadir}/IR/
 cp -r IR_files/* %{buildroot}/%{_datadir}/IR/
 
 %files
-%{_datadir}/IR/*
+%{_datadir}/IR/
 
 %changelog
 * Tue Oct 05 2021 Yann Collette <ycollette dot nospam at free.fr> 1.0.1-2

--- a/rkrlv2/rkrlv2.spec
+++ b/rkrlv2/rkrlv2.spec
@@ -51,7 +51,7 @@ sed -i -e "s/-msse -msse2 -mfpmath=sse//g" lv2/CMakeLists.txt
 
 %files
 %{_libdir}/lv2/*
-%{_datadir}/rkr.lv2/*
+%{_datadir}/rkr.lv2/
 
 %changelog
 * Thu Oct 1 2020 Yann Collette <ycollette.nospam@free.fr> - 0.0.1-4

--- a/samplebrain/samplebrain.spec
+++ b/samplebrain/samplebrain.spec
@@ -76,6 +76,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/*.desktop
 %{_bindir}/samplebrain
 %{_datadir}/applications/*.desktop
 %{_datadir}/icons/hicolor/*
+%{_datadir}/samplebrain/
 %{_datadir}/samplebrain/docs/*
 
 %changelog

--- a/saugns/saugns.spec
+++ b/saugns/saugns.spec
@@ -58,6 +58,7 @@ mv %{buildroot}/%{_datadir}/doc/%{name}/ %{buildroot}/%{_datadir}/%{name}/doc/
 %license COPYING
 %{_bindir}/*
 %{_mandir}/*
+%{_datadir}/%{name}/
 %{_datadir}/%{name}/doc/*
 %{_datadir}/%{name}/examples/*
 

--- a/smartguitar/numcpp.spec
+++ b/smartguitar/numcpp.spec
@@ -32,7 +32,8 @@ C++ implementation of the Python Numpy library.
 %doc README.md
 %license LICENSE
 %{_includedir}/NumCpp.hpp
-%{_includedir}/NumCpp/*
+%{_includedir}/NumCpp/
+%{_datadir}/NumCpp/
 %{_datadir}/NumCpp/cmake/*
 
 %changelog

--- a/smartguitar/proteus.spec
+++ b/smartguitar/proteus.spec
@@ -116,6 +116,7 @@ mv ToneLibrary-%{toneversion}/Proteus/* %{buildroot}%{_datadir}/proteus/tones/
 %files
 %doc README.md
 %license LICENSE.txt
+%{_datadir}/proteus/
 %{_datadir}/proteus/tones/*
 
 %files -n vst3-%{name}

--- a/smartguitar/smartguitar.spec
+++ b/smartguitar/smartguitar.spec
@@ -100,6 +100,7 @@ mv ToneLibrary-%{toneversion}/SmartAmp/* %{buildroot}%{_datadir}/smartamp/tones/
 %files
 %doc README.md
 %license LICENSE.txt
+%{_datadir}/smartamp/
 %{_datadir}/smartamp/tones/*
 
 %files -n vst3-%{name}

--- a/smartguitar/smartguitarpro.spec
+++ b/smartguitar/smartguitarpro.spec
@@ -95,6 +95,7 @@ mv ToneLibrary-%{toneversion}/SmartAmpPro/* %{buildroot}%{_datadir}/smartamppro/
 %doc README.md
 %license LICENSE.txt
 %{_bindir}/*
+%{_datadir}/smartamppro/
 %{_datadir}/smartamppro/models/*
 %{_datadir}/smartamppro/tones/*
 

--- a/soundscaperenderer/soundscaperenderer.spec
+++ b/soundscaperenderer/soundscaperenderer.spec
@@ -55,8 +55,8 @@ cp -ra pd/* %{buildroot}/%{_datadir}/ssr/pd/
 %doc README
 %license COPYING
 %{_bindir}/*
-%{_datadir}/doc/ssr/*
-%{_datadir}/ssr/*
+%{_datadir}/doc/ssr/
+%{_datadir}/ssr/
 %{_mandir}/*
 
 %changelog

--- a/spectmorph/spectmorph.spec
+++ b/spectmorph/spectmorph.spec
@@ -139,7 +139,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/*.desktop
 %{_datadir}/applications/*
 %{_datadir}/man/*
 %{_datadir}/pixmaps/*
-%{_datadir}/spectmorph/*
+%{_datadir}/spectmorph/
 
 %files devel
 %{_includedir}/%{name}/*

--- a/stargate/stargate.spec
+++ b/stargate/stargate.spec
@@ -91,7 +91,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/stargate.desktop
 %{_datadir}/applications/*
 %{_datadir}/mime/*
 %{_datadir}/pixmaps/*
-%{_datadir}/stargate/*
+%{_datadir}/stargate/
 
 %changelog
 * Thu Mar 09 2023 Yann Collette <ycollette.nospam@free.fr> - 23.03.1-1

--- a/stretchplayer/stretchplayer.spec
+++ b/stretchplayer/stretchplayer.spec
@@ -66,6 +66,7 @@ desktop-file-install --vendor '' \
 %{_datadir}/applications/%{name}.desktop
 %{_datadir}/icons/*
 %{_datadir}/pixmaps/*
+%{_datadir}/%{name}/
 %{_datadir}/%{name}/icons/*
 %exclude %{_datadir}/%{name}/%{name}.desktop
 

--- a/supercollider/supercollider.spec
+++ b/supercollider/supercollider.spec
@@ -122,6 +122,7 @@ chrpath --delete %{buildroot}%{_bindir}/scide
 %exclude %{_datadir}/SuperCollider/README.md
 %exclude %{_datadir}/SuperCollider/README_LINUX.md
 %exclude %{_datadir}/SuperCollider/CHANGELOG.md
+%dir %{_datadir}/SuperCollider/
 %{_datadir}/SuperCollider/HelpSource
 %{_datadir}/SuperCollider/SCClassLibrary
 %{_datadir}/SuperCollider/sounds
@@ -129,6 +130,7 @@ chrpath --delete %{buildroot}%{_bindir}/scide
 %{_datadir}/icons/*
 # scsynth
 %{_bindir}/scsynth
+%{_libdir}/SuperCollider/
 %{_libdir}/SuperCollider/plugins
 %ifnarch %{arm}
 # supernova

--- a/swami/swami.spec
+++ b/swami/swami.spec
@@ -65,9 +65,9 @@ desktop-file-install                                    \
 %files
 %doc AUTHORS ChangeLog NEWS README.md HACKERS
 %license COPYING
-%{_datadir}/%{name}/*
+%{_datadir}/%{name}/
 %{_bindir}/%{name}
-%{_libdir}/%{name}/*
+%{_libdir}/%{name}/
 %{_datadir}/applications/%{name}.desktop
 %{_datadir}/icons/hicolor/*/apps/*
 %{_datadir}/mime/packages/%{name}.xml
@@ -77,7 +77,7 @@ desktop-file-install                                    \
 
 %files devel
 %{_libdir}/lib%{name}*.so
-%{_includedir}/%{name}/*
+%{_includedir}/%{name}/
 
 %changelog
 * Tue Nov 01 2022 Yann Collette <ycollette.nospam@free.fr> - 2.2.2-24

--- a/tascar/tascar.spec
+++ b/tascar/tascar.spec
@@ -76,6 +76,7 @@ mv %buildroot/usr/lib/* %buildroot/%{_libdir}/
 %doc README.md release.md changelog
 %{_bindir}/*
 %{_libdir}/*.so
+%{_datadir}/%{name}/
 %{_datadir}/%{name}/examples/*
 
 %files devel

--- a/timemachine/timemachine.spec
+++ b/timemachine/timemachine.spec
@@ -69,7 +69,7 @@ EOF
 %doc AUTHORS ChangeLog INSTALL NEWS README.md
 %license COPYING
 %{_bindir}/%{name}
-%{_datadir}/%{name}/*
+%{_datadir}/%{name}/
 %{_datadir}/applications/*
 
 %changelog

--- a/tsunami/tsunami.spec
+++ b/tsunami/tsunami.spec
@@ -77,7 +77,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/michisoft-tsunami.des
 %doc README.md
 %license LICENSE
 %{_bindir}/tsunami
-%{_datadir}/tsunami/*
+%{_datadir}/tsunami/
 %{_datadir}/applications/michisoft-tsunami.desktop
 %{_datadir}/icons/hicolor/scalable/apps/tsunami.svg
 %{_datadir}/mime/packages/michisoft-nami.xml

--- a/xjadeo/xjadeo.spec
+++ b/xjadeo/xjadeo.spec
@@ -85,7 +85,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 %license COPYING
 %{_bindir}/*
 %{_datadir}/man/*
-%{_datadir}/xjadeo/*
+%{_datadir}/xjadeo/
 %{_datadir}/applications/*
 %{_datadir}/icons/*
 

--- a/zita/ebumeter.spec
+++ b/zita/ebumeter.spec
@@ -50,7 +50,7 @@ popd
 %defattr(-,root,root,-)
 %doc AUTHORS README* 
 %{_bindir}/ebu*
-%{_datadir}/ebumeter/*
+%{_datadir}/ebumeter/
 
 %changelog
 * Fri Feb 17 2023 Yann Collette <ycollette.nospam@free.fr> - 0.5.1-1

--- a/zita/jconvolver.spec
+++ b/zita/jconvolver.spec
@@ -52,6 +52,7 @@ popd
 %files
 %doc AUTHORS README* 
 %{_bindir}/*
+%{_datadir}/jconvolver/
 %{_datadir}/jconvolver/config/*
 
 %changelog

--- a/zita/jmatconvol.spec
+++ b/zita/jmatconvol.spec
@@ -54,6 +54,7 @@ popd
 %doc AUTHORS README*
 %license COPYING
 %{_bindir}/*
+%{_datadir}/jmatconvol/
 %{_datadir}/jmatconvol/config/*
 
 %changelog

--- a/zita/tetraproc.spec
+++ b/zita/tetraproc.spec
@@ -46,7 +46,7 @@ popd
 %files
 %doc AUTHORS README* 
 %{_bindir}/tetra*
-%{_datadir}/tetraproc/*
+%{_datadir}/tetraproc/
 
 %changelog
 * Tue Oct 20 2020 Yann Collette <ycollette.nospam@free.fr> - 0.8.6-2

--- a/zita/zita-bls1.spec
+++ b/zita/zita-bls1.spec
@@ -53,7 +53,7 @@ popd
 %doc AUTHORS README doc
 %license COPYING
 %{_bindir}/*
-%{_datadir}/zita-bls1/*
+%{_datadir}/zita-bls1/
 
 %changelog
 * Mon Oct 15 2018 Yann Collette <ycollette.nospam@free.fr> - 0.3.3-1

--- a/zita/zita-dpl1.spec
+++ b/zita/zita-dpl1.spec
@@ -51,7 +51,7 @@ popd
 %doc AUTHORS README doc
 %license COPYING
 %{_bindir}/*
-%{_datadir}/zita-dpl1/*
+%{_datadir}/zita-dpl1/
 
 %changelog
 * Mon Oct 15 2018 Yann Collette <ycollette.nospam@free.fr> - 0.3.3-1

--- a/zita/zita-mu1.spec
+++ b/zita/zita-mu1.spec
@@ -57,7 +57,7 @@ popd
 %defattr(-,root,root,-)
 %doc AUTHORS README* 
 %{_bindir}/*
-%{_datadir}/zita-mu1/*
+%{_datadir}/zita-mu1/
 
 %changelog
 * Tue May 12 2020 Yann Collette <ycollette.nospam@free.fr> - 0.3.3-1

--- a/zrythm/zrythm.spec
+++ b/zrythm/zrythm.spec
@@ -169,7 +169,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/org.zrythm.Zrythm.des
 %{_datadir}/icons/*
 %{_datadir}/locale/*
 %{_datadir}/mime/*
-%{_datadir}/zrythm/*
+%{_datadir}/zrythm/
 %{_datadir}/bash-completion/completions/zrythm
 %{_mandir}/*
 %exclude %{_libdir}/*.a


### PR DESCRIPTION
I found many cases of unowned dirs, which causes dirs to be left on the user's system when the package is uninstalled.

---

I tried to keep the changes to a minimum.

If it was simple like this:

```
%{_datadir}/%{name}/*
```

then I only removed the `*`:

```
%{_datadir}/%{name}/
```

But if there were more specific paths like this:

```
%{_datadir}/%{name}/docs/*
%{_datadir}/%{name}/examples/*
```

then I did not touch the existing lines, and added a new line:

```
%{_datadir}/%{name}/
%{_datadir}/%{name}/docs/*
%{_datadir}/%{name}/examples/*
```

This causes rpmbuild warning of "file listed twice" but is harmless.

I will set the PR to draft because I'm still checking... especially those with subpackages need to be more careful