### PR TITLE
(WIP) cardinal fixes

### DIFF
--- a/kxstudio/cardinal.spec
+++ b/kxstudio/cardinal.spec
@@ -42,6 +42,7 @@ BuildRequires: mesa-libGL-devel
 BuildRequires: speexdsp-devel
 BuildRequires: wget
 BuildRequires: desktop-file-utils
+BuildRequires: findutils
 
 Requires(pre): python3-qt5
 
@@ -118,6 +119,8 @@ install -m 644 %{SOURCE1} %{buildroot}/%{_datadir}/icons/hicolor/scalable/apps/
 
 # Remove empty file
 rm %{buildroot}%{_datadir}/%{name}/surgext/patches/README.md
+# Fix perms
+find %{buildroot}%{_datadir}/%{name} -type f -perm /a+x -exec chmod -x '{}' \+
 
 %check
 desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop

--- a/kxstudio/cardinal.spec
+++ b/kxstudio/cardinal.spec
@@ -4,7 +4,7 @@ Name:    cardinal
 Version: 23.02
 Release: 2%{?dist}
 Summary: Virtual modular synthesizer plugin
-License: GPL-2.0-or-later
+License: GPL-3.0-or-later
 URL:     https://github.com/DISTRHO/Cardinal
 
 Vendor:       Audinux
@@ -58,28 +58,24 @@ self-contained plugin version.
 
 %package -n lv2-%{name}
 Summary:  LV2 version of %{name}
-License:  GPL-2.0-or-later
 
 %description -n lv2-%{name}
 LV2 version of %{name}
 
 %package -n vst3-%{name}
 Summary:  VST3 version of %{name}
-License:  GPL-2.0-or-later
 
 %description -n vst3-%{name}
 VST3 version of %{name}
 
 %package -n vst-%{name}
 Summary:  VST2 version of %{name}
-License:  GPL-2.0-or-later
 
 %description -n vst-%{name}
 VST2 version of %{name}
 
 %package -n clap-%{name}
 Summary:  CLAP version of %{name}
-License:  GPL-2.0-or-later
 
 %description -n clap-%{name}
 CLAP version of %{name}

--- a/kxstudio/cardinal.spec
+++ b/kxstudio/cardinal.spec
@@ -126,6 +126,11 @@ find %{buildroot}%{_datadir}/%{name} -type f -perm /a+x -exec chmod -x '{}' \+
 sed -i -e 's/\r$//' %{buildroot}%{_datadir}/%{name}/ValleyAudio/res/Topograph.svg
 # Deduplicate files by soft linking
 %fdupes -s %{buildroot}%{_datadir}/%{name}
+# Make sure binaries are executable for stripping by debuginfo
+find %{buildroot}%{_libdir} \
+	\( -name '*.so' -o -name '*.clap' \) \
+	-type f \
+	-exec chmod 0755 '{}' \+
 
 %check
 desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop

--- a/kxstudio/cardinal.spec
+++ b/kxstudio/cardinal.spec
@@ -116,6 +116,9 @@ EOF
 install -m 755 -d %{buildroot}/%{_datadir}/icons/hicolor/scalable/apps/
 install -m 644 %{SOURCE1} %{buildroot}/%{_datadir}/icons/hicolor/scalable/apps/
 
+# Remove empty file
+rm %{buildroot}%{_datadir}/%{name}/surgext/patches/README.md
+
 %check
 desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 

--- a/kxstudio/cardinal.spec
+++ b/kxstudio/cardinal.spec
@@ -121,6 +121,8 @@ install -m 644 %{SOURCE1} %{buildroot}/%{_datadir}/icons/hicolor/scalable/apps/
 rm %{buildroot}%{_datadir}/%{name}/surgext/patches/README.md
 # Fix perms
 find %{buildroot}%{_datadir}/%{name} -type f -perm /a+x -exec chmod -x '{}' \+
+# Fix line endings
+sed -i -e 's/\r$//' %{buildroot}%{_datadir}/%{name}/ValleyAudio/res/Topograph.svg
 
 %check
 desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop

--- a/kxstudio/cardinal.spec
+++ b/kxstudio/cardinal.spec
@@ -46,6 +46,7 @@ BuildRequires: findutils
 BuildRequires: fdupes
 
 Requires(pre): python3-qt5
+Requires:      %{name}-common = %{version}-%{release}
 
 %description
 Cardinal, the Rack!
@@ -56,26 +57,37 @@ for FreeBSD, Linux, macOS and Windows.
 It is based on the popular VCV Rack but with a focus on being a fully
 self-contained plugin version.
 
+%package common
+Summary:   Common files for Cardinal
+BuildArch: noarch
+
+%description common
+Common data files for Cardinal standalone and plugin versions.
+
 %package -n lv2-%{name}
 Summary:  LV2 version of %{name}
+Requires: %{name}-common = %{version}-%{release}
 
 %description -n lv2-%{name}
 LV2 version of %{name}
 
 %package -n vst3-%{name}
 Summary:  VST3 version of %{name}
+Requires: %{name}-common = %{version}-%{release}
 
 %description -n vst3-%{name}
 VST3 version of %{name}
 
 %package -n vst-%{name}
 Summary:  VST2 version of %{name}
+Requires: %{name}-common = %{version}-%{release}
 
 %description -n vst-%{name}
 VST2 version of %{name}
 
 %package -n clap-%{name}
 Summary:  CLAP version of %{name}
+Requires: %{name}-common = %{version}-%{release}
 
 %description -n clap-%{name}
 CLAP version of %{name}
@@ -132,12 +144,14 @@ find %{buildroot}%{_libdir} \
 desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 
 %files
-%license LICENSE
 %{_bindir}/*
-%{_datadir}/%{name}/
-%{_datadir}/doc/%{name}/
 %{_datadir}/applications/*
 %{_datadir}/icons/hicolor/scalable/apps/*
+
+%files common
+%license LICENSE
+%{_datadir}/%{name}/
+%{_datadir}/doc/%{name}/
 
 %files -n lv2-%{name}
 %{_libdir}/lv2/*

--- a/kxstudio/cardinal.spec
+++ b/kxstudio/cardinal.spec
@@ -43,6 +43,7 @@ BuildRequires: speexdsp-devel
 BuildRequires: wget
 BuildRequires: desktop-file-utils
 BuildRequires: findutils
+BuildRequires: fdupes
 
 Requires(pre): python3-qt5
 
@@ -123,6 +124,8 @@ rm %{buildroot}%{_datadir}/%{name}/surgext/patches/README.md
 find %{buildroot}%{_datadir}/%{name} -type f -perm /a+x -exec chmod -x '{}' \+
 # Fix line endings
 sed -i -e 's/\r$//' %{buildroot}%{_datadir}/%{name}/ValleyAudio/res/Topograph.svg
+# Deduplicate files by soft linking
+%fdupes -s %{buildroot}%{_datadir}/%{name}
 
 %check
 desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop


### PR DESCRIPTION
Since it takes so long to build, I will collect all the changes first, then test it when the next version is out (in 2 weeks according to upstream)

Difference in rpm size:

package | [before](https://download.copr.fedorainfracloud.org/results/ycollet/audinux/fedora-38-x86_64/05679505-cardinal/) (Mb) | [after](https://download.copr.fedorainfracloud.org/results/jn64/playground/fedora-38-x86_64/06134171-cardinal/) (Mb) | change (%)
--|--:|--:|--:
cardinal | 81.21 | 80.12 | -1.34
clap-cardinal | 670.28 | 67.59 | -89.91
lv2-cardinal | 670.34 | 67.66 | -89.90
vst-cardinal | 446.73 | 45.06 | -89.91
vst3-cardinal | 67.61 | 67.64 | +0.04

Main difference is from stripping. The fdupes macro doesn't really do much (except remove ~70 rpmlint warnings) since the duplicates are small files like icons.

Not fully tested yet. I will test lv2 version in the next week