### PR TITLE
Build furnace with system fftw

### DIFF
--- a/furnace/furnace.spec
+++ b/furnace/furnace.spec
@@ -43,6 +43,7 @@ BuildRequires: rtmidi-devel
 BuildRequires: zlib-devel
 BuildRequires: mesa-libgbm-devel
 BuildRequires: libglvnd-devel
+BuildRequires: fftw-devel
 BuildRequires: fmt-devel
 BuildRequires: SDL2-devel
 BuildRequires: patchelf
@@ -56,10 +57,12 @@ A multi-system chiptune tracker compatible with DefleMask modules
 
 %build
 
-%cmake -DSYSTEM_FMT=ON -DSYSTEM_LIBSNDFILE=ON -DSYSTEM_RTMIDI=ON -DSYSTEM_ZLIB=ON -DSYSTEM_SDL2=ON
+# https://github.com/tildearrow/furnace#cmake-options
+%cmake -DSYSTEM_FFTW=ON -DSYSTEM_FMT=ON -DSYSTEM_LIBSNDFILE=ON \
+       -DSYSTEM_RTMIDI=ON -DSYSTEM_ZLIB=ON -DSYSTEM_SDL2=ON
 %cmake_build
 
-%install 
+%install
 
 %cmake_install
 


### PR DESCRIPTION
[Current build](https://copr.fedorainfracloud.org/coprs/ycollet/audinux/build/6484229/) can't be installed on F38 because of version mismatch with bundled fftw.

```
# dnf up
[...]
 Problem: cannot install the best update candidate for package furnace-0.5.8-3.fc38.x86_64
  - nothing provides libfftw3.so.3.6.9()(64bit) needed by furnace-0.6-3.fc38.x86_64 from copr:copr.fedorainfracloud.org:ycollet:audinux
```