### PR TITLE
Update mod-ui.spec

### DIFF
--- a/moddevices/mod-ui.spec
+++ b/moddevices/mod-ui.spec
@@ -49,7 +49,7 @@ BuildRequires: pkgconfig(lilv-0)
 
 Requires: lilv
 Requires: python3
-Requires: python3-Pillow
+Requires: python3-pillow
 Requires: python3-pyserial
 Requires: python3-tornado
 


### PR DESCRIPTION
The mod-ui package requires python3-Pillow which does not exist on fedora 39 while the package python3-pillow does exist