### PR TITLE
Original release profile for dm plugins

### DIFF
--- a/davemollen/dm-bigmuff.spec
+++ b/davemollen/dm-bigmuff.spec
@@ -65,11 +65,7 @@ LV2 version of %{name}
 
 %autosetup -n dm-BigMuff-%{commit0}
 
-rm -f .cargo/config.toml
-
 %build
-
-export RUSTFLAGS="-g -O"
 
 export CWD=`pwd`
 export RUSTUP_HOME="$CWD/rustup"

--- a/davemollen/dm-ds1.spec
+++ b/davemollen/dm-ds1.spec
@@ -65,11 +65,7 @@ LV2 version of %{name}
 
 %autosetup -n dm-DS1-%{commit0}
 
-rm -f .cargo/config.toml
-
 %build
-
-export RUSTFLAGS="-g -O"
 
 export CWD=`pwd`
 export RUSTUP_HOME="$CWD/rustup"

--- a/davemollen/dm-fuzz.spec
+++ b/davemollen/dm-fuzz.spec
@@ -65,11 +65,7 @@ LV2 version of %{name}
 
 %autosetup -n dm-Fuzz-%{commit0}
 
-rm -f .cargo/config.toml
-
 %build
-
-export RUSTFLAGS="-g -O"
 
 export CWD=`pwd`
 export RUSTUP_HOME="$CWD/rustup"

--- a/davemollen/dm-lfo.spec
+++ b/davemollen/dm-lfo.spec
@@ -49,11 +49,7 @@ LV2 version of %{name}
 
 %autosetup -n dm-LFO-%{commit0}
 
-rm -f .cargo/config.toml
-
 %build
-
-export RUSTFLAGS="-g -O"
 
 export CWD=`pwd`
 export RUSTUP_HOME="$CWD/rustup"

--- a/davemollen/dm-octaver.spec
+++ b/davemollen/dm-octaver.spec
@@ -49,11 +49,7 @@ LV2 version of %{name}
 
 %autosetup -n dm-Octaver-%{commit0}
 
-rm -f .cargo/config.toml
-
 %build
-
-export RUSTFLAGS="-g -O"
 
 export CWD=`pwd`
 export RUSTUP_HOME="$CWD/rustup"

--- a/davemollen/dm-rat.spec
+++ b/davemollen/dm-rat.spec
@@ -65,11 +65,7 @@ LV2 version of %{name}
 
 %autosetup -n dm-Rat-%{commit0}
 
-rm -f .cargo/config.toml
-
 %build
-
-export RUSTFLAGS="-g -O"
 
 export CWD=`pwd`
 export RUSTUP_HOME="$CWD/rustup"

--- a/davemollen/dm-repeat.spec
+++ b/davemollen/dm-repeat.spec
@@ -65,11 +65,7 @@ LV2 version of %{name}
 
 %autosetup -n dm-Repeat-%{commit0}
 
-rm -f .cargo/config.toml
-
 %build
-
-export RUSTFLAGS="-g -O"
 
 export CWD=`pwd`
 export RUSTUP_HOME="$CWD/rustup"

--- a/davemollen/dm-reverb.spec
+++ b/davemollen/dm-reverb.spec
@@ -65,11 +65,7 @@ LV2 version of %{name}
 
 %autosetup -n dm-Reverb-%{commit0}
 
-rm -f .cargo/config.toml
-
 %build
-
-export RUSTFLAGS="-g -O"
 
 export CWD=`pwd`
 export RUSTUP_HOME="$CWD/rustup"

--- a/davemollen/dm-reverse.spec
+++ b/davemollen/dm-reverse.spec
@@ -53,11 +53,7 @@ LV2 version of %{name}
 
 %autosetup -n dm-Reverse-%{commit0}
 
-rm -f .cargo/config.toml
-
 %build
-
-export RUSTFLAGS="-g -O"
 
 export CWD=`pwd`
 export RUSTUP_HOME="$CWD/rustup"

--- a/davemollen/dm-sd1.spec
+++ b/davemollen/dm-sd1.spec
@@ -65,11 +65,7 @@ LV2 version of %{name}
 
 %autosetup -n dm-SD1-%{commit0}
 
-rm -f .cargo/config.toml
-
 %build
-
-export RUSTFLAGS="-g -O"
 
 export CWD=`pwd`
 export RUSTUP_HOME="$CWD/rustup"

--- a/davemollen/dm-shredmaster.spec
+++ b/davemollen/dm-shredmaster.spec
@@ -65,11 +65,7 @@ LV2 version of %{name}
 
 %autosetup -n dm-Shredmaster-%{commit0}
 
-rm -f .cargo/config.toml
-
 %build
-
-export RUSTFLAGS="-g -O"
 
 export CWD=`pwd`
 export RUSTUP_HOME="$CWD/rustup"

--- a/davemollen/dm-spaceecho.spec
+++ b/davemollen/dm-spaceecho.spec
@@ -65,11 +65,7 @@ LV2 version of %{name}
 
 %autosetup -n dm-SpaceEcho-%{commit0}
 
-rm -f .cargo/config.toml
-
 %build
-
-export RUSTFLAGS="-g -O"
 
 export CWD=`pwd`
 export RUSTUP_HOME="$CWD/rustup"

--- a/davemollen/dm-stutter.spec
+++ b/davemollen/dm-stutter.spec
@@ -65,11 +65,7 @@ LV2 version of %{name}
 
 %autosetup -n dm-Stutter-%{commit0}
 
-rm -f .cargo/config.toml
-
 %build
-
-export RUSTFLAGS="-g -O"
 
 export CWD=`pwd`
 export RUSTUP_HOME="$CWD/rustup"

--- a/davemollen/dm-timewarp.spec
+++ b/davemollen/dm-timewarp.spec
@@ -65,11 +65,7 @@ LV2 version of %{name}
 
 %autosetup -n dm-TimeWarp-%{commit0}
 
-rm -f .cargo/config.toml
-
 %build
-
-export RUSTFLAGS="-g -O"
 
 export CWD=`pwd`
 export RUSTUP_HOME="$CWD/rustup"

--- a/davemollen/dm-tubescreamer.spec
+++ b/davemollen/dm-tubescreamer.spec
@@ -65,11 +65,7 @@ LV2 version of %{name}
 
 %autosetup -n dm-TubeScreamer-%{commit0}
 
-rm -f .cargo/config.toml
-
 %build
-
-export RUSTFLAGS="-g -O"
 
 export CWD=`pwd`
 export RUSTUP_HOME="$CWD/rustup"

--- a/davemollen/dm-vibrato.spec
+++ b/davemollen/dm-vibrato.spec
@@ -65,11 +65,7 @@ LV2 version of %{name}
 
 %autosetup -n dm-Vibrato-%{commit0}
 
-rm -f .cargo/config.toml
-
 %build
-
-export RUSTFLAGS="-g -O"
 
 export CWD=`pwd`
 export RUSTUP_HOME="$CWD/rustup"

--- a/davemollen/dm-whammy.spec
+++ b/davemollen/dm-whammy.spec
@@ -65,11 +65,7 @@ LV2 version of %{name}
 
 %autosetup -n dm-Whammy-%{commit0}
 
-rm -f .cargo/config.toml
-
 %build
-
-export RUSTFLAGS="-g -O"
 
 export CWD=`pwd`
 export RUSTUP_HOME="$CWD/rustup"


### PR DESCRIPTION
I became aware you included some of my plugins here. 

I looked at the lv2 build script and suggest you keep the original release profile in `.cargo/config.toml`. I see you remove it and pass some RUSTFLAGS instead. The original release profile should result in a more cpu efficient binary and binary optimized for size. I actually expect the performance difference to be quite notable. Which is why I'd recommend to keep the `.cargo/config.toml`. It may result in slower compile times though. Is there any reason you removed this?