### PR TITLE
Patch for Issue #83, Desktop file for atlas-06-synthesizer has wrong Exec name

### DIFF
--- a/atlas-06-synthetizer/atlas-06-synthesizer.spec
+++ b/atlas-06-synthetizer/atlas-06-synthesizer.spec
@@ -80,7 +80,7 @@ cat > %{buildroot}%{_datadir}/applications/%{name}.desktop <<EOF
 [Desktop Entry]
 Encoding=UTF-8
 Name=%name
-Exec=%{name}
+Exec=ATLAS-06
 Icon=%{name}
 Comment=ATLAS 06 Synthesizer
 Terminal=false

--- a/atlas-06-synthetizer/source-atlas.sh
+++ b/atlas-06-synthetizer/source-atlas.sh
@@ -3,14 +3,14 @@
 # Usage: ./source-atlas.sh <tag>
 #        ./source-atlas.sh master
 
-git clone https://github.com/sbadon122/ATLAS-06-Synthesizer
+git clone --depth=1 https://github.com/sbadon122/ATLAS-06-Synthesizer
 cd ATLAS-06-Synthesizer
 git checkout $1
 if [ $? == 1 ]; then
     echo "Wrong branch / tag name: $1"
     exit 1
 fi
-git submodule update --init --recursive --progress
+git submodule update --depth=1 --init --recursive --progress
 find . -name .git -exec rm -rf {} \;
 cd ..
 tar cvfz ATLAS-06-Synthesizer.tar.gz ATLAS-06-Synthesizer/*


### PR DESCRIPTION
atlas-06-synthetizer
- updating Exec name in desktop file
- using --depth=1 for a shallow git clone when creating the source archive

This is to address issue #83, _Desktop file for atlas-06-synthesizer has wrong Exec name_