### PR TITLE
jamin: patching C init, adding wrapper script and foo-plugins requirement

### DIFF
--- a/jamin/1010_clear_history_state.patch
+++ b/jamin/1010_clear_history_state.patch
@@ -1,0 +1,12 @@
+diff --git a/src/state.c b/src/state.c
+index 2cbc925..8341222 100644
+--- a/src/state.c
++++ b/src/state.c
+@@ -234,6 +234,7 @@ void s_clear_history()
+     }
+     g_list_free(history);
+     history = NULL;
++    undo_pos = NULL;
+     s_history_add("Initial state");
+     undo_pos = history->next;
+     s_restore_state((s_state *)history->data);

--- a/jamin/1011_interface_c.patch
+++ b/jamin/1011_interface_c.patch
@@ -1,0 +1,277 @@
+diff --git a/src/interface.c b/src/interface.c
+index f981122..977c80a 100644
+--- a/src/interface.c
++++ b/src/interface.c
+@@ -5066,11 +5066,11 @@ create_pref_dialog (void)
+   GtkWidget *vbox163;
+   GtkWidget *hbox70;
+   GtkWidget *MinGainLabel;
+-  GObject *MinGainSpin_adj;
++  GtkAdjustment *MinGainSpin_adj;
+   GtkWidget *MinGainSpin;
+   GtkWidget *hbox71;
+   GtkWidget *MaxGainLabel;
+-  GObject *MaxGainSpin_adj;
++  GtkAdjustment *MaxGainSpin_adj;
+   GtkWidget *MaxGainSpin;
+   GtkWidget *GraphicEQLabel;
+   GtkWidget *hbox78;
+@@ -5078,14 +5078,14 @@ create_pref_dialog (void)
+   GtkWidget *CrossfadeFrame;
+   GtkWidget *hbox72;
+   GtkWidget *CrossfadeTimeLabel;
+-  GObject *CrossfadeTimeSpin_adj;
++  GtkAdjustment *CrossfadeTimeSpin_adj;
+   GtkWidget *CrossfadeTimeSpin;
+   GtkWidget *CrossfadeLabel;
+   GtkWidget *warningFrame;
+   GtkWidget *alignment7;
+   GtkWidget *warningLevelHbox;
+   GtkWidget *Meter_warning_level__dbFS_;
+-  GObject *warningLevelSpinButton_adj;
++  GtkAdjustment *warningLevelSpinButton_adj;
+   GtkWidget *warningLevelSpinButton;
+   GtkWidget *warningLabel;
+   GtkWidget *SpectrumEvent;
+@@ -5095,7 +5095,7 @@ create_pref_dialog (void)
+   GtkWidget *SpectrumComboBox;
+   GtkWidget *hbox73;
+   GtkWidget *UpdateFrequencyLabel;
+-  GObject *UpdateFrequencySpin_adj;
++  GtkAdjustment *UpdateFrequencySpin_adj;
+   GtkWidget *UpdateFrequencySpin;
+   GtkWidget *SpectrumLabel;
+   GtkWidget *hbox75;
+@@ -5109,7 +5109,7 @@ create_pref_dialog (void)
+   GtkWidget *rmsWindowFrame;
+   GtkWidget *table17;
+   GtkWidget *rmsTimeLabel;
+-  GObject *rmsTimeValue_adj;
++  GtkAdjustment *rmsTimeValue_adj;
+   GtkWidget *rmsTimeValue;
+   GtkWidget *rmsSamplesLabel;
+   GtkWidget *rmsSamples;
+@@ -5119,9 +5119,9 @@ create_pref_dialog (void)
+   GtkWidget *DelayTable;
+   GtkWidget *LowDelayLabel;
+   GtkWidget *MidDelayLabel;
+-  GObject *LowDelaySpinButton_adj;
++  GtkAdjustment *LowDelaySpinButton_adj;
+   GtkWidget *LowDelaySpinButton;
+-  GObject *MidDelaySpinButton_adj;
++  GtkAdjustment *MidDelaySpinButton_adj;
+   GtkWidget *MidDelaySpinButton;
+   GtkWidget *label3180;
+   GtkWidget *hbox77;
+@@ -5159,7 +5159,7 @@ create_pref_dialog (void)
+   gtk_window_set_type_hint (GTK_WINDOW (pref_dialog), GDK_WINDOW_TYPE_HINT_DIALOG);
+ 
+  // dialog_vbox1 = GTK_DIALOG (pref_dialog)->vbox;
+-  dialog_vbox1 = gtk_dialog_get_content_area(pref_dialog); 
++  dialog_vbox1 = gtk_dialog_get_content_area(GTK_DIALOG(pref_dialog));
+   gtk_widget_set_name (dialog_vbox1, "dialog_vbox1");
+   gtk_widget_show (dialog_vbox1);
+ 
+@@ -5190,7 +5190,7 @@ create_pref_dialog (void)
+   gtk_widget_show (MinGainLabel);
+   gtk_box_pack_start (GTK_BOX (hbox70), MinGainLabel, FALSE, FALSE, 0);
+ 
+-  MinGainSpin_adj = gtk_adjustment_new (-12, -70, -1, 1, 10, 10);
++  MinGainSpin_adj = GTK_ADJUSTMENT(gtk_adjustment_new (-12, -70, -1, 1, 10, 10));
+   MinGainSpin = gtk_spin_button_new (GTK_ADJUSTMENT (MinGainSpin_adj), 1, 0);
+   gtk_widget_set_name (MinGainSpin, "MinGainSpin");
+   gtk_widget_show (MinGainSpin);
+@@ -5207,7 +5207,7 @@ create_pref_dialog (void)
+   gtk_widget_show (MaxGainLabel);
+   gtk_box_pack_start (GTK_BOX (hbox71), MaxGainLabel, FALSE, FALSE, 0);
+ 
+-  MaxGainSpin_adj = gtk_adjustment_new (12, 1, 70, 1, 10, 10);
++  MaxGainSpin_adj = GTK_ADJUSTMENT(gtk_adjustment_new (12, 1, 70, 1, 10, 10));
+   MaxGainSpin = gtk_spin_button_new (GTK_ADJUSTMENT (MaxGainSpin_adj), 1, 0);
+   gtk_widget_set_name (MaxGainSpin, "MaxGainSpin");
+   gtk_widget_show (MaxGainSpin);
+@@ -5247,7 +5247,7 @@ create_pref_dialog (void)
+   gtk_widget_show (CrossfadeTimeLabel);
+   gtk_box_pack_start (GTK_BOX (hbox72), CrossfadeTimeLabel, FALSE, FALSE, 0);
+ 
+-  CrossfadeTimeSpin_adj = gtk_adjustment_new (1, 0, 2, 0.10000000149, 0.10000000149, 0.10000000149);
++  CrossfadeTimeSpin_adj = GTK_ADJUSTMENT(gtk_adjustment_new (1, 0, 2, 0.10000000149, 0.10000000149, 0.10000000149));
+   CrossfadeTimeSpin = gtk_spin_button_new (GTK_ADJUSTMENT (CrossfadeTimeSpin_adj), 1, 1);
+   gtk_widget_set_name (CrossfadeTimeSpin, "CrossfadeTimeSpin");
+   gtk_widget_show (CrossfadeTimeSpin);
+@@ -5322,10 +5322,10 @@ create_pref_dialog (void)
+   gtk_widget_set_name (SpectrumComboBox, "SpectrumComboBox");
+   gtk_widget_show (SpectrumComboBox);
+   gtk_container_add (GTK_CONTAINER (eventbox69), SpectrumComboBox);
+-  gtk_combo_box_text_append (GTK_COMBO_BOX (SpectrumComboBox), NULL, _("Pre EQ"));
+-  gtk_combo_box_text_append (GTK_COMBO_BOX (SpectrumComboBox), NULL, _("Post EQ"));
+-  gtk_combo_box_text_append (GTK_COMBO_BOX (SpectrumComboBox), NULL, _("Post Compressor"));
+-  gtk_combo_box_text_append (GTK_COMBO_BOX (SpectrumComboBox), NULL,_("Output"));
++  gtk_combo_box_text_append (GTK_COMBO_BOX_TEXT (SpectrumComboBox), NULL, _("Pre EQ"));
++  gtk_combo_box_text_append (GTK_COMBO_BOX_TEXT (SpectrumComboBox), NULL, _("Post EQ"));
++  gtk_combo_box_text_append (GTK_COMBO_BOX_TEXT (SpectrumComboBox), NULL, _("Post Compressor"));
++  gtk_combo_box_text_append (GTK_COMBO_BOX_TEXT (SpectrumComboBox), NULL,_("Output"));
+ 
+   hbox73 = gtk_hbox_new (TRUE, 0);
+   gtk_widget_set_name (hbox73, "hbox73");
+@@ -5409,7 +5409,7 @@ create_pref_dialog (void)
+   rmsTimeLabel = gtk_label_new (_("Time (ms):"));
+   gtk_widget_set_name (rmsTimeLabel, "rmsTimeLabel");
+   gtk_widget_show (rmsTimeLabel);
+-  gtk_grid_attach (GTK_GRID (table17), rmsTimeLabel, 0, 1, 0, 1);
++  gtk_grid_attach (GTK_GRID (table17), rmsTimeLabel, 0, 1, 1, 1);
+    //                 (GtkAttachOptions) (GTK_FILL),
+    //                 (GtkAttachOptions) (0), 0, 0);
+   gtk_misc_set_alignment (GTK_MISC (rmsTimeLabel), 0, 0.5);
+@@ -5418,7 +5418,7 @@ create_pref_dialog (void)
+   rmsTimeValue = gtk_spin_button_new (GTK_ADJUSTMENT (rmsTimeValue_adj), 1, 0);
+   gtk_widget_set_name (rmsTimeValue, "rmsTimeValue");
+   gtk_widget_show (rmsTimeValue);
+-  gtk_grid_attach (GTK_GRID (table17), rmsTimeValue, 1, 2, 0, 1);
++  gtk_grid_attach (GTK_GRID (table17), rmsTimeValue, 1, 2, 1, 1);
+   //                  (GtkAttachOptions) (GTK_EXPAND | GTK_FILL),
+    //                 (GtkAttachOptions) (0), 0, 0);
+ 
+@@ -5465,7 +5465,7 @@ create_pref_dialog (void)
+   LowDelayLabel = gtk_label_new (_("Low band"));
+   gtk_widget_set_name (LowDelayLabel, "LowDelayLabel");
+   gtk_widget_show (LowDelayLabel);
+-  gtk_grid_attach (GTK_GRID (DelayTable), LowDelayLabel, 0, 1, 0, 1);
++  gtk_grid_attach (GTK_GRID (DelayTable), LowDelayLabel, 0, 1, 1, 1);
+   //                  (GtkAttachOptions) (GTK_FILL),
+   //                  (GtkAttachOptions) (0), 0, 0);
+   gtk_misc_set_alignment (GTK_MISC (LowDelayLabel), 0, 0.5);
+@@ -5478,16 +5478,16 @@ create_pref_dialog (void)
+   //                  (GtkAttachOptions) (0), 0, 0);
+   gtk_misc_set_alignment (GTK_MISC (MidDelayLabel), 0, 0.5);
+ 
+-  LowDelaySpinButton_adj = gtk_adjustment_new (2, 0, 2, 0.00999999977648, 0.10000000149, 0.10000000149);
++  LowDelaySpinButton_adj = GTK_ADJUSTMENT(gtk_adjustment_new (2, 0, 2, 0.00999999977648, 0.10000000149, 0.10000000149));
+   LowDelaySpinButton = gtk_spin_button_new (GTK_ADJUSTMENT (LowDelaySpinButton_adj), 1, 2);
+   gtk_widget_set_name (LowDelaySpinButton, "LowDelaySpinButton");
+   gtk_widget_show (LowDelaySpinButton);
+-  gtk_grid_attach (GTK_GRID (DelayTable), LowDelaySpinButton, 1, 2, 0, 1);
++  gtk_grid_attach (GTK_GRID (DelayTable), LowDelaySpinButton, 1, 2, 1, 1);
+   //                  (GtkAttachOptions) (GTK_EXPAND | GTK_FILL),
+   //                  (GtkAttachOptions) (0), 0, 0);
+   gtk_spin_button_set_numeric (GTK_SPIN_BUTTON (LowDelaySpinButton), TRUE);
+ 
+-  MidDelaySpinButton_adj = gtk_adjustment_new (0.5, 0, 0.5, 0.00999999977648, 0.10000000149, 0.10000000149);
++  MidDelaySpinButton_adj = GTK_ADJUSTMENT(gtk_adjustment_new (0.5, 0, 0.5, 0.00999999977648, 0.10000000149, 0.10000000149));
+   MidDelaySpinButton = gtk_spin_button_new (GTK_ADJUSTMENT (MidDelaySpinButton_adj), 1, 2);
+   gtk_widget_set_name (MidDelaySpinButton, "MidDelaySpinButton");
+   gtk_widget_show (MidDelaySpinButton);
+@@ -5528,21 +5528,21 @@ create_pref_dialog (void)
+   gtk_widget_set_name (ColorsComboBox, "ColorsComboBox");
+   gtk_widget_show (ColorsComboBox);
+   gtk_container_add (GTK_CONTAINER (eventbox68), ColorsComboBox);
+-  gtk_combo_box_text_append (GTK_COMBO_BOX (ColorsComboBox), NULL,_("Low Band Compressor"));
+-  gtk_combo_box_text_append (GTK_COMBO_BOX (ColorsComboBox), NULL,_("Mid Band Compressor"));
+-  gtk_combo_box_text_append (GTK_COMBO_BOX (ColorsComboBox), NULL,_("High Band Compressor"));
+-  gtk_combo_box_text_append (GTK_COMBO_BOX (ColorsComboBox), NULL,_("Ganged Controls"));
+-  gtk_combo_box_text_append (GTK_COMBO_BOX (ColorsComboBox), NULL,_("Parametric Handles"));
+-  gtk_combo_box_text_append (GTK_COMBO_BOX (ColorsComboBox), NULL,_("HDEQ Curve"));
+-  gtk_combo_box_text_append (GTK_COMBO_BOX (ColorsComboBox), NULL,_("HDEQ Spectrum"));
+-  gtk_combo_box_text_append (GTK_COMBO_BOX (ColorsComboBox), NULL,_("HDEQ Grid"));
+-  gtk_combo_box_text_append (GTK_COMBO_BOX (ColorsComboBox), NULL,_("HDEQ Background"));
+-  gtk_combo_box_text_append (GTK_COMBO_BOX (ColorsComboBox), NULL,_("Text"));
+-  gtk_combo_box_text_append (GTK_COMBO_BOX (ColorsComboBox), NULL,_("Meter Normal"));
+-  gtk_combo_box_text_append (GTK_COMBO_BOX (ColorsComboBox), NULL, _("Meter Warning"));
+-  gtk_combo_box_text_append (GTK_COMBO_BOX (ColorsComboBox), NULL,_("Meter Over"));
+-  gtk_combo_box_text_append (GTK_COMBO_BOX (ColorsComboBox), NULL,_("Meter Peak"));
+-  gtk_combo_box_text_append (GTK_COMBO_BOX (ColorsComboBox), NULL,_("Reset All Colors To Defaults"));
++  gtk_combo_box_text_append (GTK_COMBO_BOX_TEXT (ColorsComboBox), NULL,_("Low Band Compressor"));
++  gtk_combo_box_text_append (GTK_COMBO_BOX_TEXT (ColorsComboBox), NULL,_("Mid Band Compressor"));
++  gtk_combo_box_text_append (GTK_COMBO_BOX_TEXT (ColorsComboBox), NULL,_("High Band Compressor"));
++  gtk_combo_box_text_append (GTK_COMBO_BOX_TEXT (ColorsComboBox), NULL,_("Ganged Controls"));
++  gtk_combo_box_text_append (GTK_COMBO_BOX_TEXT (ColorsComboBox), NULL,_("Parametric Handles"));
++  gtk_combo_box_text_append (GTK_COMBO_BOX_TEXT (ColorsComboBox), NULL,_("HDEQ Curve"));
++  gtk_combo_box_text_append (GTK_COMBO_BOX_TEXT (ColorsComboBox), NULL,_("HDEQ Spectrum"));
++  gtk_combo_box_text_append (GTK_COMBO_BOX_TEXT (ColorsComboBox), NULL,_("HDEQ Grid"));
++  gtk_combo_box_text_append (GTK_COMBO_BOX_TEXT (ColorsComboBox), NULL,_("HDEQ Background"));
++  gtk_combo_box_text_append (GTK_COMBO_BOX_TEXT (ColorsComboBox), NULL,_("Text"));
++  gtk_combo_box_text_append (GTK_COMBO_BOX_TEXT (ColorsComboBox), NULL,_("Meter Normal"));
++  gtk_combo_box_text_append (GTK_COMBO_BOX_TEXT (ColorsComboBox), NULL, _("Meter Warning"));
++  gtk_combo_box_text_append (GTK_COMBO_BOX_TEXT (ColorsComboBox), NULL,_("Meter Over"));
++  gtk_combo_box_text_append (GTK_COMBO_BOX_TEXT (ColorsComboBox), NULL,_("Meter Peak"));
++  gtk_combo_box_text_append (GTK_COMBO_BOX_TEXT (ColorsComboBox), NULL,_("Reset All Colors To Defaults"));
+ 
+   ColorsLabel = gtk_label_new (_("<i><b>Colors</b></i>"));
+   gtk_widget_set_name (ColorsLabel, "ColorsLabel");
+@@ -5572,8 +5572,8 @@ create_pref_dialog (void)
+   gtk_widget_set_name (limiter_combo, "limiter_combo");
+   gtk_widget_show (limiter_combo);
+   gtk_container_add (GTK_CONTAINER (eventbox67), limiter_combo);
+-  gtk_combo_box_text_append (GTK_COMBO_BOX (limiter_combo), NULL,_("Steve Harris' fast_lookahead_limiter"));
+-  gtk_combo_box_text_append (GTK_COMBO_BOX (limiter_combo), NULL,_("Sampo Savolainen's foo_limiter"));
++  gtk_combo_box_text_append (GTK_COMBO_BOX_TEXT (limiter_combo), NULL,_("Steve Harris' fast_lookahead_limiter"));
++  gtk_combo_box_text_append (GTK_COMBO_BOX_TEXT (limiter_combo), NULL,_("Sampo Savolainen's foo_limiter"));
+ 
+   limiter_frame_label = gtk_label_new (_("<b>Limiter</b>"));
+   gtk_widget_set_name (limiter_frame_label, "limiter_frame_label");
+@@ -5632,7 +5632,7 @@ create_pref_dialog (void)
+   gtk_frame_set_label_widget (GTK_FRAME (output_meter_numeric_display_frame), output_meter_numeric_display_label);
+   gtk_label_set_use_markup (GTK_LABEL (output_meter_numeric_display_label), TRUE);
+ 
+-  dialog_action_area1 = gtk_dialog_get_action_area(pref_dialog); // GTK_DIALOG (pref_dialog)->action_area;
++  dialog_action_area1 = gtk_dialog_get_action_area(GTK_DIALOG(pref_dialog)); // GTK_DIALOG (pref_dialog)->action_area;
+   gtk_widget_set_name (dialog_action_area1, "dialog_action_area1");
+   gtk_widget_show (dialog_action_area1);
+   gtk_button_box_set_layout (GTK_BUTTON_BOX (dialog_action_area1), GTK_BUTTONBOX_EDGE);
+@@ -5909,7 +5909,7 @@ create_scene_name_dialog (void)
+   gtk_window_set_title (GTK_WINDOW (scene_name_dialog), _("Scene X Name"));
+   gtk_window_set_type_hint (GTK_WINDOW (scene_name_dialog), GDK_WINDOW_TYPE_HINT_DIALOG);
+ 
+-  dialog_vbox2 = gtk_dialog_get_content_area(scene_name_dialog);
++  dialog_vbox2 = gtk_dialog_get_content_area(GTK_DIALOG(scene_name_dialog));
+   gtk_widget_set_name (dialog_vbox2, "dialog_vbox2");
+   gtk_widget_show (dialog_vbox2);
+ 
+@@ -5919,7 +5919,7 @@ create_scene_name_dialog (void)
+   gtk_box_pack_start (GTK_BOX (dialog_vbox2), scene_name_entry, FALSE, FALSE, 0);
+   gtk_entry_set_max_length (GTK_ENTRY (scene_name_entry), 99);
+ 
+-  dialog_action_area3 = gtk_dialog_get_action_area(scene_name_dialog);
++  dialog_action_area3 = gtk_dialog_get_action_area(GTK_DIALOG(scene_name_dialog));
+   gtk_widget_set_name (dialog_action_area3, "dialog_action_area3");
+   gtk_widget_show (dialog_action_area3);
+   gtk_button_box_set_layout (GTK_BUTTON_BOX (dialog_action_area3), GTK_BUTTONBOX_END);
+@@ -6190,7 +6190,7 @@ create_about_dialog (void)
+   gtk_window_set_title (GTK_WINDOW (about_dialog), _("About JAMin"));
+   gtk_window_set_type_hint (GTK_WINDOW (about_dialog), GDK_WINDOW_TYPE_HINT_DIALOG);
+ 
+-  dialog_vbox3 = gtk_dialog_get_content_area(about_dialog);
++  dialog_vbox3 = gtk_dialog_get_content_area(GTK_DIALOG(about_dialog));
+   gtk_widget_set_name (dialog_vbox3, "dialog_vbox3");
+   gtk_widget_show (dialog_vbox3);
+   gtk_widget_set_size_request (dialog_vbox3, 395, 431);
+@@ -6300,7 +6300,7 @@ create_about_dialog (void)
+   gtk_widget_show (label330);
+   gtk_notebook_set_tab_label (GTK_NOTEBOOK (notebook2), gtk_notebook_get_nth_page (GTK_NOTEBOOK (notebook2), 3), label330);
+ 
+-  dialog_action_area4 = gtk_dialog_get_action_area(about_dialog);
++  dialog_action_area4 = gtk_dialog_get_action_area(GTK_DIALOG(about_dialog));
+   gtk_widget_set_name (dialog_action_area4, "dialog_action_area4");
+   gtk_widget_show (dialog_action_area4);
+   gtk_button_box_set_layout (GTK_BUTTON_BOX (dialog_action_area4), GTK_BUTTONBOX_END);
+@@ -6606,13 +6606,13 @@ create_window3 (void)
+   gtk_widget_set_name (combobox1, "combobox1");
+   gtk_widget_show (combobox1);
+   gtk_box_pack_start (GTK_BOX (vbox167), combobox1, FALSE, TRUE, 0);
+-  gtk_combo_box_text_append (GTK_COMBO_BOX (combobox1), NULL, _("Rock"));
+-  gtk_combo_box_text_append (GTK_COMBO_BOX (combobox1), NULL, _("Classical"));
+-  gtk_combo_box_text_append (GTK_COMBO_BOX (combobox1), NULL, _("Jazz"));
+-  gtk_combo_box_text_append (GTK_COMBO_BOX (combobox1), NULL, _("Blues"));
+-  gtk_combo_box_text_append (GTK_COMBO_BOX (combobox1), NULL, _("Techno"));
+-  gtk_combo_box_text_append (GTK_COMBO_BOX (combobox1), NULL, _("DnB"));
+-  gtk_combo_box_text_append (GTK_COMBO_BOX (combobox1), NULL, _("Pop"));
++  gtk_combo_box_text_append (GTK_COMBO_BOX_TEXT (combobox1), NULL, _("Rock"));
++  gtk_combo_box_text_append (GTK_COMBO_BOX_TEXT (combobox1), NULL, _("Classical"));
++  gtk_combo_box_text_append (GTK_COMBO_BOX_TEXT (combobox1), NULL, _("Jazz"));
++  gtk_combo_box_text_append (GTK_COMBO_BOX_TEXT (combobox1), NULL, _("Blues"));
++  gtk_combo_box_text_append (GTK_COMBO_BOX_TEXT (combobox1), NULL, _("Techno"));
++  gtk_combo_box_text_append (GTK_COMBO_BOX_TEXT (combobox1), NULL, _("DnB"));
++  gtk_combo_box_text_append (GTK_COMBO_BOX_TEXT (combobox1), NULL, _("Pop"));
+ 
+   hbox_w3_1 = gtk_hbox_new (FALSE, 0);
+   gtk_widget_set_name (hbox_w3_1, "hbox_w3_1");

--- a/jamin/1012_hdeq_c_hscale.patch
+++ b/jamin/1012_hdeq_c_hscale.patch
@@ -1,0 +1,24 @@
+diff --git a/src/hdeq.c b/src/hdeq.c
+index 7ed31ee..8650c37 100644
+--- a/src/hdeq.c
++++ b/src/hdeq.c
+@@ -139,7 +139,7 @@ static GtkMenu           *HDEQ_menu;
+ //static GdkPixmap *hdeq_pixmap = NULL;
+ 
+ 
+-static GtkHScale       *l_low2mid, *l_mid2high;
++static GtkScale       *l_low2mid, *l_mid2high;
+ static GtkWidget       *l_comp[3];
+ static GtkLabel        *l_low2mid_lbl, *l_mid2high_lbl, *l_comp_lbl[3], 
+                        *l_EQ_curve_lbl = NULL, *l_c_curve_lbl[3];
+@@ -252,8 +252,8 @@ void bind_hdeq ()
+         that was set in glade-2.  If you change the widget name in glade-2
+         you'll break the app.  */
+ 
+-    l_low2mid = GTK_HSCALE (lookup_widget (main_window, "low2mid"));
+-    l_mid2high = GTK_HSCALE (lookup_widget (main_window, "mid2high"));
++    l_low2mid = GTK_SCALE (lookup_widget (main_window, "low2mid"));
++    l_mid2high = GTK_SCALE (lookup_widget (main_window, "mid2high"));
+     l_low2mid_lbl = GTK_LABEL (lookup_widget (main_window, "low2mid_lbl"));
+     l_mid2high_lbl = GTK_LABEL (lookup_widget (main_window, "mid2high_lbl"));
+ 

--- a/jamin/1013_gtkmeter_c_queue_draw.patch
+++ b/jamin/1013_gtkmeter_c_queue_draw.patch
@@ -1,0 +1,11 @@
+diff --git a/src/gtkmeter.c b/src/gtkmeter.c
+index aba8542..9fc24bc 100644
+--- a/src/gtkmeter.c
++++ b/src/gtkmeter.c
+@@ -1038,5 +1038,5 @@ void gtk_meter_set_warn_point(GtkMeter *meter, gfloat pt)
+ 		(priv->iec_upper - priv->iec_lower);
+     }
+ 
+-    gtk_widget_draw(GTK_WIDGET(meter), NULL);
++    gtk_widget_queue_draw(GTK_WIDGET(meter));
+ }

--- a/jamin/1014_compressor_c_curve_update.patch
+++ b/jamin/1014_compressor_c_curve_update.patch
@@ -1,0 +1,37 @@
+diff --git a/src/compressor-ui.c b/src/compressor-ui.c
+index b94c31e..351f62e 100644
+--- a/src/compressor-ui.c
++++ b/src/compressor-ui.c
+@@ -226,7 +226,7 @@ void re_changed(int id, float value)
+ 
+ 
+   compressors[i].release = value;
+-  comp_curve_update;
++  comp_curve_update(i);
+ }
+ 
+ void th_changed(int id, float value)
+@@ -273,9 +273,9 @@ void th_changed(int id, float value)
+   compressors[i].threshold = value;
+   if (auto_gain[i]) {
+     calc_auto_gain(i);
+-  } else {
++  } // else {
+ 	comp_curve_update(i);
+-  }
++  // }
+   gtk_meter_set_warn_point(le_meter[i], value);
+ }
+ 
+@@ -323,9 +323,9 @@ void ra_changed(int id, float value)
+   compressors[i].ratio = value;
+   if (auto_gain[i]) {
+     calc_auto_gain(i);
+-  } else {
++  } // else {
+ 	comp_curve_update(i);
+-  }
++  // }
+   gtk_meter_set_warn_point(le_meter[i], value);
+ }
+ 

--- a/jamin/jamin-wrapper
+++ b/jamin/jamin-wrapper
@@ -1,0 +1,81 @@
+#!/bin/sh
+
+# jamin-wrapper
+#
+# - Introduces an '-X' arg that will run jamin under gdb
+#
+# - When no jam file was specified and the user has not created a
+#   ~/.jamin/default.jam file, adds an arg for loading the default
+#   jam file from jamin's defualt.jam example, using XDG_RUNTIME_DIRS
+#
+# - If LADSPA_PATH is not already set in the environment, ensures
+#   LADSPA_PATH will be set for the location of ladspa-swh-plugins.
+#   This environment variable is used within jamin
+
+OPTSTR="Xf:hj:n:s:c:rpil:vVdFTtgD"
+PARSED=$(getopt -n jamin-wrapper -o ${OPTSTR} -- "$@");
+RS=$?
+if [ ${RS} -ne 0 ]; then
+    exec jamin -h
+fi
+eval set -- "${PARSED}"
+declare -a ARGS
+
+NEED_DEFAULT_JAM=1
+NEED_GDB=0
+
+while true; do
+    case "$1" in
+        -f)
+            NEED_DEFAULT_JAM=0
+        ;;
+        -X)
+            NEED_GDB=1
+            shift
+            continue
+        ;;
+        --)
+            shift
+            break
+        ;;
+        *)
+        ;;
+    esac
+    ARGS[${#ARGS[@]}]="$1"
+    shift
+done
+
+
+if [ -z "${LADSPA_PATH}" ]; then
+    SC4_PTH=$(rpm -ql ladspa-swh-plugins | grep sc4_1882)
+    if [ -n "${SC4_PTH}" ]; then
+        LADSPA_PATH=$(dirname "${SC4_PTH}")
+    else
+        echo "$0: LADSPA sc4_1882 plugin not found. Is ladspa-swh-plugins installed?" 1>&2
+        exit 1
+    fi
+fi
+
+if [ "${NEED_DEFAULT_JAM}" -eq 1 ] &&
+    ! [ -e "${HOME}/.jamin/default.jam" ]  &&
+    [ -n "${XDG_DATA_DIRS}" ]; then
+    DEFAULT_JAM=$(echo "$XDG_DATA_DIRS" | awk '
+        BEGIN {RS=":"}
+        // {
+            test_jam = ($1 "/jamin/examples/default.jam");
+            if (getline nop < test_jam >= 0) { print test_jam; exit }
+        }')
+    if [ -n "${DEFAULT_JAM}" ]; then
+        ARGS[${#ARGS[@]}]="-f"
+        ARGS[${#ARGS[@]}]="${DEFAULT_JAM}"
+    fi
+fi
+
+
+if [ "${NEED_GDB}" -ne 0 ]; then
+    set -x
+    LADSPA_PATH="${LADSPA_PATH}" exec gdb --args jamin "${ARGS[@]}" "${@}"
+else
+    set -x
+    LADSPA_PATH="${LADSPA_PATH}" exec jamin "${ARGS[@]}" "${@}"
+fi

--- a/jamin/jamin.spec
+++ b/jamin/jamin.spec
@@ -6,7 +6,7 @@
 Name: jamin
 Summary: JACK Audio Connection Kit (JACK) Audio Mastering interface
 Version: 0.98.9
-Release: 2%{?dist}
+Release: 3%{?dist}
 License: GPL-2.0-or-later
 URL: http://jamin.sourceforge.net
 ExclusiveArch: x86_64 aarch64
@@ -15,6 +15,7 @@ Vendor:       Audinux
 Distribution: Audinux
 
 Source0: https://salsa.debian.org/multimedia-team/jamin/-/archive/upstream/0.98.9_git20170111_199091_repack1/jamin-upstream-0.98.9_git20170111_199091_repack1.tar.gz#/%{name}-%{version}.tar.gz
+Source1: jamin-wrapper
 Patch0: 1003_add_dynamic_linking.patch
 Patch1: 1004_install_correct_dir.patch
 Patch2: 1005_desktop_file.patch
@@ -24,6 +25,7 @@ Patch5: jamin-gcc10.patch
 Patch6: jamin-spectrum.patch
 Patch7: NEWS.patch
 Patch8: 1006-fix-callback.patch
+Patch9: 1010_clear_history_state.patch
 
 BuildRequires: gcc
 BuildRequires: make
@@ -41,7 +43,10 @@ BuildRequires: perl-XML-Parser
 BuildRequires: desktop-file-utils
 
 Requires: ladspa-swh-plugins
-# Add ladspa-foo (not packaged anymore) as a Requires
+Requires: ladspa-foo-plugins
+# gawk is needed for jamin-wrapper
+Requires: gawk
+
 
 %description
 JAMin is the JACK Audio Connection Kit (JACK) Audio Mastering interface. JAMin
@@ -64,6 +69,9 @@ NOCONFIGURE=indeed ./autogen.sh
 
 %make_install
 
+# install wrapper script
+install -m 755 %{SOURCE1} %{buildroot}%{_bindir}
+
 # move icon to the proper freedesktop location
 install -m 755 -d %{buildroot}%{_datadir}/icons/hicolor/scalable/apps
 mv %{buildroot}%{_datadir}/icons/%{name}.svg %{buildroot}%{_datadir}/icons/hicolor/scalable/apps/
@@ -83,7 +91,7 @@ Comment[cz]=JACK Audio Mastering interface
 Comment[fr]=Interface de masterisation JACK Audio
 Comment[ru]=JAMin -- приложение для мастеринга звука
 Keywords=audio;sound;mastering;ladspa
-Exec=jamin
+Exec=jamin-wrapper
 Icon=jamin
 MimeType=application/x-jamin;
 StartupNotify=true

--- a/jamin/jamin.spec
+++ b/jamin/jamin.spec
@@ -26,6 +26,7 @@ Patch6: jamin-spectrum.patch
 Patch7: NEWS.patch
 Patch8: 1006-fix-callback.patch
 Patch9: 1010_clear_history_state.patch
+Patch10: 1011_interface_c.patch
 
 BuildRequires: gcc
 BuildRequires: make

--- a/jamin/jamin.spec
+++ b/jamin/jamin.spec
@@ -27,6 +27,9 @@ Patch7: NEWS.patch
 Patch8: 1006-fix-callback.patch
 Patch9: 1010_clear_history_state.patch
 Patch10: 1011_interface_c.patch
+Patch11: 1012_hdeq_c_hscale.patch
+Patch12: 1013_gtkmeter_c_queue_draw.patch
+Patch13: 1014_compressor_c_curve_update.patch
 
 BuildRequires: gcc
 BuildRequires: make


### PR DESCRIPTION
This changeset adds a check to prevent jamin from accessing a null pointer during application init, as well as a wrapper script for launching jamin.

The ladspa-foo-plugins package, now available with Audinux, is added back to the jamin spec file.

This also adds a jamin-wrapper script for fedora.


So I think it's pretty neat that this equalizer application Jamin is still being built and it's still available on Fedora. Although I'm not well versed in the history of the project, I think that his project may have emerged along with the Center for Computer Research in Music and Acoustics at Stanford University https://ccrma.stanford.edu/

imo jamin literallly adds depth to just about any audio that can be processed through jack (or pipewire now, lol). and it still works!

If one could offer to share any usage notes in the pull request, albeit short of documentation for the project:

- Within the jamin main window, in the HDEQ user interface, some of the yellow visual elements there are dots with draggable handles, for adjusting the equalizer spectrum.

- The top section of the Jamin UI appears to be related to the support for Open Scene Control (liblo). Jamin will still process audio, regardless of the play/pause state there.

- In this release, jamin will not select a new jack client name if the default (or provided) jack client name is in use. If Jamin states that it cannot connect to the jack server but the jack server is running (e.g emulated with pipewire) then jamin may need to be launched with a new client name e.g `jamin-wrapper -n Jamin2`

- Using qpwgraph or one's favorite pipewire/jack routing application, it may be relatively straightforward to use jamin for processing the output of anything that provides a direct jack interface - such as a few of the media players do. It might not seem as straightforward to use jamin for processing all (as otherwise unprocessed) audio output w/ pipewire or pulse. Maybe this could be managed with specific ALSA settings, though I've not tested this lol.

- For purposes of music playback, it may seem to  be especially suited for media players that would offer a direct Jack interface, e.g Aqualung, as well a couple of those that suport mpd (e.g Cantata?). Using one's favorite jack routing application, for instance one could connect the aqualung (or other) jack outputs to the jamin client's jack inputs, then connect the jamin client's master outputs to the respective inputs of one's selected audio device, and hit play lol.

- Of course, jamin also allows providing the low, mid, and high output ranges, each to a separate set of jack inputs. Hypothetically, this could be used to power three separate ranges of speakers.

- When jamin starts up - at least when using pipewire for the jack emulation - then the successive pairs of these low/mid/high range outputs (provided by jamin) might become automatically connected to the inputs of successive audio devices (e.g low range to bluetooth audio, mid range to HDMI audio, etc). This may often require that these jack outputs would be disconnected from these inputs, then that the jamin master outputs would be connected to the one audio device in use, before it could be used normally.  (I'm not sure if this is because of jamin. I'll try to test an approach for this under a development fork for jamin)

- There are  a few glib critical assertions during jamin startup. A couple of these may be related to a width of zero (0) being provided when initializing the UI elements in jamin. These are probably not fatal, but would certainly add to the output when the application is run under a console. (One might wonder how one could update these UI elements to _not_ emit the critical assertions. If one could provide any detail at this, the source files affected here may have been generated with glade for Gtk 2 or some earlier glade for gtk3. Happily, they're still portable with Gtk 3 it seems. So, there was an idea to try to port the application to C++ and gtkmm-3.0 for subsequent development. Regardless of the fork, here there is already a working jamin built with the original sources - super!)

- I think it probably needs more documentation than this lol,

If any bug reports would show up for jamin and here at the copr, I could try to field those at the relatively new jaminpp (jamin++) project over at https://github.com/coaux/jaminpp  It's not an official fork however, and as such it's not mentioned in this changeset. 

The fork was created from the sources maintained by the Debian Multimedia team. I could try to field any bug reports though, lol. 

I'm just glad it still builds. I hope others may find it useful too. Maybe it runs with this patch, lol